### PR TITLE
Added Enter Key + non-alphanumeric char compatibility to scrcpy

### DIFF
--- a/apps/demo/src/pages/scrcpy.tsx
+++ b/apps/demo/src/pages/scrcpy.tsx
@@ -1000,7 +1000,7 @@ class ScrcpyPageState {
         if (!this.client) {
             return;
         }
-
+        
         const { key, code } = e;
         if (key.match(/^[!-`{-~]$/i)) {
             this.client!.injectText(key);

--- a/apps/demo/src/pages/scrcpy.tsx
+++ b/apps/demo/src/pages/scrcpy.tsx
@@ -1002,7 +1002,7 @@ class ScrcpyPageState {
         }
 
         const { key, code } = e;
-        if (key.match(/^[a-z0-9]$/i)) {
+        if (key.match(/^[!-`{-~]$/i)) {
             this.client!.injectText(key);
             return;
         }
@@ -1010,6 +1010,7 @@ class ScrcpyPageState {
         const keyCode = ({
             Backspace: AndroidKeyCode.Delete,
             Space: AndroidKeyCode.Space,
+            Enter: AndroidKeyCode.Enter,
         } as Record<string, AndroidKeyCode | undefined>)[code];
 
         if (keyCode) {

--- a/libraries/scrcpy/src/message.ts
+++ b/libraries/scrcpy/src/message.ts
@@ -96,6 +96,7 @@ export enum AndroidKeyCode {
     Y,
     Z,
     Space = 62,
+    Enter = 66,
     Delete = 67,
     AppSwitch = 187,
 }


### PR DESCRIPTION
I improved the regex used for the injectText filter to allow for the special characters within the ASCII character-set using character ranges that still minimize the amount of scanning done with the ignorecase flag due to the ignore case flag present. The full list of newly allowed characters is:
`!`, `"`, `#`, `$`, `%`, `&`, `'`, `(`, `)`, `*`, `+`, `,`, `-`, `.`, `/`, `:`, `;`, `<`, `=`, `>`, `?`, `@`, `[`, `\`, `]`, `^`, `_`, <code>\`</code>, `{`, `|`, `}`, and `~`.

This regex change can be examined and compared at https://regex101.com/r/MueHkf/1 with version 1 being the final replacement, version 2 being the original regex formula, and version 3 demonstrating a more verbose version of the range that I made.

The enter key compatibility was added via adding it to a list of recognized PC keyboard key-presses that already included `Space` and `Backspace`, and adding the appropriate translation into a recognized android key press (with the values being `Enter` and `Enter = 66` respectively.

If you are yume-chan and want to test these changes for yourself before implementing them, or you are someone else who finds this useful, a copy of the github pages with these changes implemented is accessible at https://lordgiacomos.github.io/ya-webadb.

The information I used to get the information for the enter key from the PC side is located at https://www.w3.org/TR/uievents-key/, and the spreadsheet that I used to get the Android-side information, containing a list of android key codes based off of information found in the scrcpy source code as well as a list of ASCII characters and their order can be found at https://docs.google.com/spreadsheets/d/1gzOfz_99v5goQnjZ9szzCanWHVQZDCdApDiI4xMih-Y. 