### PR TITLE
Emulate physical HID mouse via AOA protocol

### DIFF
--- a/apps/demo/src/components/scrcpy/state.tsx
+++ b/apps/demo/src/components/scrcpy/state.tsx
@@ -28,7 +28,9 @@ import { fetchServer } from "./fetch-server";
 import {
     AoaKeyboardInjector,
     KeyboardInjector,
+    MouseInjector,
     ScrcpyKeyboardInjector,
+    ScrcpyMouseInjector,
 } from "./input";
 import { MuxerStream, RECORD_STATE } from "./recorder";
 import { H264Decoder, SETTING_STATE } from "./settings";
@@ -63,6 +65,7 @@ export class ScrcpyPageState {
 
     client: AdbScrcpyClient | undefined = undefined;
     hoverHelper: ScrcpyHoverHelper | undefined = undefined;
+    mouse: MouseInjector | undefined = undefined;
     keyboard: KeyboardInjector | undefined = undefined;
 
     async pushServer() {
@@ -357,6 +360,8 @@ export class ScrcpyPageState {
                 this.running = true;
             });
 
+            this.mouse = new ScrcpyMouseInjector(client, this.hoverHelper!);
+
             if (GLOBAL_STATE.backend instanceof AdbWebUsbBackend) {
                 this.keyboard = await AoaKeyboardInjector.register(
                     GLOBAL_STATE.backend.device
@@ -388,6 +393,9 @@ export class ScrcpyPageState {
             RECORD_STATE.recorder.stop();
             RECORD_STATE.recording = false;
         }
+
+        this.mouse?.dispose();
+        this.mouse = undefined;
 
         this.keyboard?.dispose();
         this.keyboard = undefined;

--- a/common/changes/@yume-chan/scrcpy/feat-aoa_2023-02-23-10-14.json
+++ b/common/changes/@yume-chan/scrcpy/feat-aoa_2023-02-23-10-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yume-chan/scrcpy",
+      "comment": "Add `AndroidMotionEventButton` enum definition",
+      "type": "none"
+    }
+  ],
+  "packageName": "@yume-chan/scrcpy"
+}

--- a/libraries/scrcpy/src/control/inject-touch.ts
+++ b/libraries/scrcpy/src/control/inject-touch.ts
@@ -6,6 +6,16 @@ import Struct, {
 
 import { ScrcpyControlMessageType } from "./type.js";
 
+export enum AndroidMotionEventButton {
+    Primary = 0x01,
+    Secondary = 0x02,
+    Tertiary = 0x04,
+    Back = 0x08,
+    Forward = 0x10,
+    StylusPrimary = 0x20,
+    StylusSecondary = 0x40,
+}
+
 // https://developer.android.com/reference/android/view/MotionEvent#constants_1
 export enum AndroidMotionEventAction {
     Down,


### PR DESCRIPTION
Fixes #475, fixes #489

TODOs:

- [ ] Should have a tip for mouse capture
- [ ] Press ESC when mouse captured will release mouse capture, not forwarding ESC to device. Maybe HID mouse can only be used in full screen with keyboard lock #498
- [ ] Ignore initial mouse button down until it's up
- [ ] Dynamically switch injection mode #489
- [ ] Emulate HID touch screen