### PR TITLE
Simplify usage of `AdbWebUsbBackend` and custom WebUSB implementations

### DIFF
--- a/apps/demo/src/components/connect.tsx
+++ b/apps/demo/src/components/connect.tsx
@@ -10,7 +10,8 @@ import {
 } from "@fluentui/react";
 import { Adb, AdbBackend, AdbPacketData, AdbPacketInit } from "@yume-chan/adb";
 import AdbDirectSocketsBackend from "@yume-chan/adb-backend-direct-sockets";
-import AdbWebUsbBackend, {
+import {
+    AdbWebUsbBackendManager,
     AdbWebUsbBackendWatcher,
 } from "@yume-chan/adb-backend-webusb";
 import AdbWsBackend from "@yume-chan/adb-backend-ws";
@@ -40,7 +41,8 @@ function _Connect(): JSX.Element | null {
 
     const [usbBackendList, setUsbBackendList] = useState<AdbBackend[]>([]);
     const updateUsbBackendList = useCallback(async () => {
-        const backendList: AdbBackend[] = await AdbWebUsbBackend.getDevices();
+        const backendList: AdbBackend[] =
+            await AdbWebUsbBackendManager.BROWSER!.getDevices();
         setUsbBackendList(backendList);
         return backendList;
     }, []);
@@ -48,7 +50,7 @@ function _Connect(): JSX.Element | null {
     useEffect(
         () => {
             // Only run on client
-            const supported = AdbWebUsbBackend.isSupported();
+            const supported = !!AdbWebUsbBackendManager.BROWSER;
             setSupported(supported);
 
             if (!supported) {
@@ -70,7 +72,8 @@ function _Connect(): JSX.Element | null {
                         );
                         return;
                     }
-                }
+                },
+                window.navigator.usb
             );
 
             return () => watcher.dispose();
@@ -165,7 +168,7 @@ function _Connect(): JSX.Element | null {
     };
 
     const addUsbBackend = useCallback(async () => {
-        const backend = await AdbWebUsbBackend.requestDevice();
+        const backend = await AdbWebUsbBackendManager.BROWSER!.requestDevice();
         setSelectedBackend(backend);
         await updateUsbBackendList();
     }, [updateUsbBackendList]);

--- a/common/changes/@yume-chan/adb-backend-webusb/feat-webusb-manager_2023-02-12-14-07.json
+++ b/common/changes/@yume-chan/adb-backend-webusb/feat-webusb-manager_2023-02-12-14-07.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@yume-chan/adb-backend-webusb",
+      "comment": "Add the `AdbWebUsbBackendManager` class to simplify the usage with custom WebUSB implementations (for example the `usb` NPM package).",
+      "type": "none"
+    }
+  ],
+  "packageName": "@yume-chan/adb-backend-webusb"
+}

--- a/libraries/adb-backend-webusb/README.md
+++ b/libraries/adb-backend-webusb/README.md
@@ -26,7 +26,7 @@ Backend for `@yume-chan/adb` using WebUSB ([MDN](https://developer.mozilla.org/e
 
 | Node.js | `usb` NPM Package |
 | ------- | ----------------- |
-| 10.5    | 2.9.0             |
+| 10.5    | 2.8.1             |
 
 Node.js doesn't have native support for WebUSB API, but the [`usb`](https://www.npmjs.com/package/usb) NPM package provides a WebUSB compatible API.
 

--- a/libraries/adb-backend-webusb/README.md
+++ b/libraries/adb-backend-webusb/README.md
@@ -2,7 +2,7 @@
 
 Backend for `@yume-chan/adb` using WebUSB ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/USB), [Spec](https://wicg.github.io/webusb)) API.
 
--   [Requirements](#requirements)
+-   [Use in browser](#use-in-browser)
 -   [Use in Node.js](#use-in-nodejs)
 -   [`AdbWebUsbBackend`](#adbwebusbbackend)
     -   [constructor](#constructor)
@@ -13,7 +13,11 @@ Backend for `@yume-chan/adb` using WebUSB ([MDN](https://developer.mozilla.org/e
     -   [`requestDevice`](#requestdevice)
     -   [`getDevices`](#getdevices)
 
-## Requirements
+## Use in browser
+
+| Chrome | Edge | Firefox | Internet Explorer | Safari |
+| ------ | ---- | ------- | ----------------- | ------ |
+| 61     | 79   | No      | No                | No     |
 
 WebUSB API requires [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS).
 
@@ -26,9 +30,13 @@ Chrome will treat `localhost` as secure, but if you want to access a dev server 
 
 ## Use in Node.js
 
-Node.js doesn't have native support for WebUSB API, but the [`usb`](https://www.npmjs.com/package/usb) NPM package has a `webusb` export that provides a WebUSB compatible API.
+| Node.js | `usb` NPM Package |
+| ------- | ----------------- |
+| 10.5    | 2.9.0             |
 
-The constructors of `AdbWebUsbBackend`, `AdbWebUsbBackendManager` and `AdbWebUsbBackendWatcher` all have a `usb` parameter that can be used to specify the WebUSB API implementation.
+Node.js doesn't have native support for WebUSB API, but the [`usb`](https://www.npmjs.com/package/usb) NPM package provides a WebUSB compatible API.
+
+To use a custom WebUSB API implementation, pass it to the constructor of `AdbWebUsbBackend`, `AdbWebUsbBackendManager` and `AdbWebUsbBackendWatcher` via the `usb` parameter.
 
 ## `AdbWebUsbBackend`
 
@@ -42,9 +50,9 @@ public constructor(
 );
 ```
 
-Create a new instance of `AdbWebBackend` using a `USBDevice` instance you already have.
+Create a new instance of `AdbWebBackend` using a specified `USBDevice` instance.
 
-`USBDevice` type is from WebUSB API.
+`USBDevice` and `USB` types are from WebUSB API.
 
 The `filters` parameter specifies the `classCode`, `subclassCode` and `protocolCode` to use when searching for ADB interface. The default value is `[{ classCode: 0xff, subclassCode: 0x42, protocolCode: 0x1 }]`, defined by Google.
 
@@ -68,7 +76,7 @@ A helper class that wraps the WebUSB API.
 public static readonly BROWSER: AdbWebUsbBackendManager | undefined;
 ```
 
-Gets the instance of AdbWebUsbBackendManager using browser WebUSB implementation.
+Gets the instance of `AdbWebUsbBackendManager` using browser WebUSB implementation.
 
 May be `undefined` if the browser does not support WebUSB.
 
@@ -104,4 +112,5 @@ public async getDevices(
 ```
 
 Get all connected and authenticated devices.
+
 This is a convince method for `usb.getDevices()`.

--- a/libraries/adb-backend-webusb/README.md
+++ b/libraries/adb-backend-webusb/README.md
@@ -12,21 +12,15 @@ Backend for `@yume-chan/adb` using WebUSB ([MDN](https://developer.mozilla.org/e
     -   [constructor](#constructor-1)
     -   [`requestDevice`](#requestdevice)
     -   [`getDevices`](#getdevices)
+-   [Note on secure context](#note-on-secure-context)
 
 ## Use in browser
 
-| Chrome | Edge | Firefox | Internet Explorer | Safari |
-| ------ | ---- | ------- | ----------------- | ------ |
-| 61     | 79   | No      | No                | No     |
+| Chrome         | Edge           | Firefox | Internet Explorer | Safari |
+| -------------- | -------------- | ------- | ----------------- | ------ |
+| 61<sup>1</sup> | 79<sup>1</sup> | No      | No                | No     |
 
-WebUSB API requires [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS).
-
-Chrome will treat `localhost` as secure, but if you want to access a dev server running on another machine, follow the steps to add the domain name to allowlist:
-
-1. Open `chrome://flags/#unsafely-treat-insecure-origin-as-secure`
-2. Add the protocol and domain part of your url (e.g. `http://192.168.0.100:9000`) to the input box
-3. Choose `Enable` from the dropdown menu
-4. Restart browser
+<sup>1</sup>: Chrome for Android is supported, Chrome for iOS is NOT supported.
 
 ## Use in Node.js
 
@@ -114,3 +108,14 @@ public async getDevices(
 Get all connected and authenticated devices.
 
 This is a convince method for `usb.getDevices()`.
+
+## Note on secure context
+
+WebUSB requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS).
+
+`localhost` is considered secure, so local development works. But to access a self-hosted server running on another machine, either add a certificate, or add the domain name to the allowlist on each client machine:
+
+1. Open `chrome://flags/#unsafely-treat-insecure-origin-as-secure`
+2. Add the protocol and domain part of your url (e.g. `http://192.168.0.100:9000`) to the input box
+3. Choose `Enable` from the dropdown menu
+4. Restart browser

--- a/libraries/adb-backend-webusb/src/backend.ts
+++ b/libraries/adb-backend-webusb/src/backend.ts
@@ -130,7 +130,7 @@ export class AdbWebUsbBackendStream
         device: USBDevice,
         inEndpoint: USBEndpoint,
         outEndpoint: USBEndpoint,
-        usbManager = window.navigator.usb
+        usbManager: USB
     ) {
         let closed = false;
 
@@ -232,79 +232,8 @@ export class AdbWebUsbBackendStream
 }
 
 export class AdbWebUsbBackend implements AdbBackend {
-    /**
-     * Check if WebUSB API is supported by the browser.
-     *
-     * @returns `true` if WebUSB is supported by the current browser.
-     */
-    public static isSupported(): boolean {
-        return !!globalThis.navigator?.usb;
-    }
-
-    /**
-     * Request access to a connected device.
-     * This is a convince method for `usb.requestDevice()`.
-     * @param filters
-     * The filters to apply to the device list.
-     *
-     * It must have `classCode`, `subclassCode` and `protocolCode` fields for selecting the ADB interface,
-     * but might also have `vendorId`, `productId` or `serialNumber` fields to limit the displayed device list.
-     *
-     * Defaults to {@link ADB_DEFAULT_DEVICE_FILTER}.
-     * @param usbManager
-     * A WebUSB compatible interface.
-     * For example, `usb` NPM package for Node.js has a `webusb` object that can be used here.
-     *
-     * Defaults to `window.navigator.usb` (will throw an error if not exist).
-     * @returns The `AdbWebUsbBackend` instance if the user selected a device,
-     * or `undefined` if the user cancelled the device picker.
-     */
-    public static async requestDevice(
-        filters: AdbDeviceFilter[] = [ADB_DEFAULT_DEVICE_FILTER],
-        usbManager = window.navigator.usb
-    ): Promise<AdbWebUsbBackend | undefined> {
-        try {
-            const device = await usbManager.requestDevice({
-                filters,
-            });
-            return new AdbWebUsbBackend(device, filters, usbManager);
-        } catch (e) {
-            // User cancelled the device picker
-            if (e instanceof DOMException && e.name === "NotFoundError") {
-                return undefined;
-            }
-
-            throw e;
-        }
-    }
-
-    /**
-     * Get all connected and authenticated devices.
-     * This is a convince method for `usb.getDevices()`.
-     * @param filters
-     * The filters to apply to the device list.
-     *
-     * It must have `classCode`, `subclassCode` and `protocolCode` fields for selecting the ADB interface,
-     * but might also have `vendorId`, `productId` or `serialNumber` fields to limit the displayed device list.
-     *
-     * Defaults to {@link ADB_DEFAULT_DEVICE_FILTER}.
-     * @param usbManager
-     * A WebUSB compatible interface.
-     * For example, `usb` NPM package for Node.js has a `webusb` object that can be used here.
-     *
-     * Defaults to `window.navigator.usb` (will throw an error if not exist).
-     * @returns An array of `AdbWebUsbBackend` instances for all connected and authenticated devices.
-     */
-    public static async getDevices(
-        filters: AdbDeviceFilter[] = [ADB_DEFAULT_DEVICE_FILTER],
-        usbManager = window.navigator.usb
-    ): Promise<AdbWebUsbBackend[]> {
-        const devices = await usbManager.getDevices();
-        return devices.map((device) => new AdbWebUsbBackend(device, filters));
-    }
-
     private _filters: AdbDeviceFilter[];
-    private _usbManager: USB;
+    private _usb: USB;
 
     private _device: USBDevice;
     public get device() {
@@ -328,11 +257,11 @@ export class AdbWebUsbBackend implements AdbBackend {
     public constructor(
         device: USBDevice,
         filters: AdbDeviceFilter[] = [ADB_DEFAULT_DEVICE_FILTER],
-        usbManager = window.navigator.usb
+        usb: USB
     ) {
         this._device = device;
         this._filters = filters;
-        this._usbManager = usbManager;
+        this._usb = usb;
     }
 
     /**
@@ -380,7 +309,7 @@ export class AdbWebUsbBackend implements AdbBackend {
             this._device,
             inEndpoint,
             outEndpoint,
-            this._usbManager
+            this._usb
         );
     }
 }

--- a/libraries/adb-backend-webusb/src/backend.ts
+++ b/libraries/adb-backend-webusb/src/backend.ts
@@ -249,9 +249,9 @@ export class AdbWebUsbBackend implements AdbBackend {
     }
 
     /**
-     * Create a new instance of `AdbWebBackend` using a `USBDevice` instance you already have.
+     * Create a new instance of `AdbWebBackend` using a specified `USBDevice` instance
      *
-     * @param device The `USBDevice` instance you already have.
+     * @param device The `USBDevice` instance obtained elsewhere.
      * @param filters The filters to use when searching for ADB interface. Defaults to {@link ADB_DEFAULT_DEVICE_FILTER}.
      */
     public constructor(

--- a/libraries/adb-backend-webusb/src/index.ts
+++ b/libraries/adb-backend-webusb/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./backend.js";
-export { AdbWebUsbBackend as default } from "./backend.js";
+export * from "./manager.js";
 export * from "./watcher.js";

--- a/libraries/adb-backend-webusb/src/manager.ts
+++ b/libraries/adb-backend-webusb/src/manager.ts
@@ -1,0 +1,90 @@
+import type { AdbDeviceFilter } from "./backend.js";
+import { ADB_DEFAULT_DEVICE_FILTER, AdbWebUsbBackend } from "./backend.js";
+
+export class AdbWebUsbBackendManager {
+    /**
+     * Gets the instance of AdbWebUsbBackendManager using browser WebUSB implementation.
+     *
+     * May be `undefined` if the browser does not support WebUSB.
+     */
+    public static readonly BROWSER =
+        typeof window !== "undefined" && !!window.navigator.usb
+            ? new AdbWebUsbBackendManager(window.navigator.usb)
+            : undefined;
+
+    private _usb: USB;
+
+    /**
+     * Create a new instance of `AdbWebUsbBackendManager` using the specified WebUSB API implementation.
+     * @param usb A WebUSB compatible interface.
+     */
+    public constructor(usb: USB) {
+        this._usb = usb;
+    }
+
+    /**
+     * Request access to a connected device.
+     * This is a convince method for `usb.requestDevice()`.
+     * @param filters
+     * The filters to apply to the device list.
+     *
+     * It must have `classCode`, `subclassCode` and `protocolCode` fields for selecting the ADB interface,
+     * but might also have `vendorId`, `productId` or `serialNumber` fields to limit the displayed device list.
+     *
+     * Defaults to {@link ADB_DEFAULT_DEVICE_FILTER}.
+     * @param usbManager
+     * A WebUSB compatible interface.
+     * For example, `usb` NPM package for Node.js has a `webusb` object that can be used here.
+     *
+     * Defaults to `window.navigator.usb` (will throw an error if not exist).
+     * @returns The `AdbWebUsbBackend` instance if the user selected a device,
+     * or `undefined` if the user cancelled the device picker.
+     */
+    public async requestDevice(
+        filters: AdbDeviceFilter[] = [ADB_DEFAULT_DEVICE_FILTER]
+    ): Promise<AdbWebUsbBackend | undefined> {
+        try {
+            const device = await this._usb.requestDevice({
+                filters,
+            });
+            return new AdbWebUsbBackend(device, filters, this._usb);
+        } catch (e) {
+            // User cancelled the device picker
+            // TODO: investigate what error the `usb` NPM package will throw
+            if (
+                typeof DOMException !== "undefined" &&
+                e instanceof DOMException &&
+                e.name === "NotFoundError"
+            ) {
+                return undefined;
+            }
+
+            throw e;
+        }
+    }
+    /**
+     * Get all connected and authenticated devices.
+     * This is a convince method for `usb.getDevices()`.
+     * @param filters
+     * The filters to apply to the device list.
+     *
+     * It must have `classCode`, `subclassCode` and `protocolCode` fields for selecting the ADB interface,
+     * but might also have `vendorId`, `productId` or `serialNumber` fields to limit the displayed device list.
+     *
+     * Defaults to {@link ADB_DEFAULT_DEVICE_FILTER}.
+     * @param usbManager
+     * A WebUSB compatible interface.
+     * For example, `usb` NPM package for Node.js has a `webusb` object that can be used here.
+     *
+     * Defaults to `window.navigator.usb` (will throw an error if not exist).
+     * @returns An array of `AdbWebUsbBackend` instances for all connected and authenticated devices.
+     */
+    public async getDevices(
+        filters: AdbDeviceFilter[] = [ADB_DEFAULT_DEVICE_FILTER]
+    ): Promise<AdbWebUsbBackend[]> {
+        const devices = await this._usb.getDevices();
+        return devices.map(
+            (device) => new AdbWebUsbBackend(device, filters, this._usb)
+        );
+    }
+}

--- a/libraries/adb-backend-webusb/src/manager.ts
+++ b/libraries/adb-backend-webusb/src/manager.ts
@@ -49,11 +49,14 @@ export class AdbWebUsbBackendManager {
             });
             return new AdbWebUsbBackend(device, filters, this._usb);
         } catch (e) {
-            // User cancelled the device picker
-            // TODO: investigate what error the `usb` NPM package will throw
+            // No device selected
+            // This check is compatible with both Browser implementation
+            // and `usb` NPM package from version 2.9.0
+            // https://github.com/node-usb/node-usb/issues/573
             if (
-                typeof DOMException !== "undefined" &&
-                e instanceof DOMException &&
+                typeof e === "object" &&
+                e !== null &&
+                "name" in e &&
                 e.name === "NotFoundError"
             ) {
                 return undefined;
@@ -62,6 +65,7 @@ export class AdbWebUsbBackendManager {
             throw e;
         }
     }
+
     /**
      * Get all connected and authenticated devices.
      * This is a convince method for `usb.getDevices()`.

--- a/libraries/adb-backend-webusb/src/manager.ts
+++ b/libraries/adb-backend-webusb/src/manager.ts
@@ -51,7 +51,7 @@ export class AdbWebUsbBackendManager {
         } catch (e) {
             // No device selected
             // This check is compatible with both Browser implementation
-            // and `usb` NPM package from version 2.9.0
+            // and `usb` NPM package from version 2.8.1
             // https://github.com/node-usb/node-usb/issues/573
             if (
                 typeof e === "object" &&

--- a/libraries/adb-backend-webusb/src/watcher.ts
+++ b/libraries/adb-backend-webusb/src/watcher.ts
@@ -1,29 +1,25 @@
 export class AdbWebUsbBackendWatcher {
-    private callback: (newDeviceSerial?: string) => void;
+    private _callback: (newDeviceSerial?: string) => void;
+    private _usb: USB;
 
-    public constructor(callback: (newDeviceSerial?: string) => void) {
-        this.callback = callback;
+    public constructor(callback: (newDeviceSerial?: string) => void, usb: USB) {
+        this._callback = callback;
+        this._usb = usb;
 
-        window.navigator.usb.addEventListener("connect", this.handleConnect);
-        window.navigator.usb.addEventListener(
-            "disconnect",
-            this.handleDisconnect
-        );
+        this._usb.addEventListener("connect", this.handleConnect);
+        this._usb.addEventListener("disconnect", this.handleDisconnect);
     }
 
     public dispose(): void {
-        window.navigator.usb.removeEventListener("connect", this.handleConnect);
-        window.navigator.usb.removeEventListener(
-            "disconnect",
-            this.handleDisconnect
-        );
+        this._usb.removeEventListener("connect", this.handleConnect);
+        this._usb.removeEventListener("disconnect", this.handleDisconnect);
     }
 
     private handleConnect = (e: USBConnectionEvent) => {
-        this.callback(e.device.serialNumber);
+        this._callback(e.device.serialNumber);
     };
 
     private handleDisconnect = () => {
-        this.callback();
+        this._callback();
     };
 }


### PR DESCRIPTION
Breaking changes:

| Old | New |
|---|----|
| `AdbWebUsbBackend.isSupported()` | `!!AdbWebUsbBackendManager.BROWSER` |
| `AdbWebUsbBackend.getDevices()` | `AdbWebUsbBackendManager.BROWSER!.getDevices()` |
| `AdbWebUsbBackend.requestDevice()` | `AdbWebUsbBackendManager.BROWSER!.requestDevice()` |