### PR TITLE
fix: rollup build failed

### DIFF
--- a/libraries/stream-extra/package.json
+++ b/libraries/stream-extra/package.json
@@ -34,18 +34,23 @@
     "dependencies": {
         "@yume-chan/async": "^2.2.0",
         "@yume-chan/struct": "workspace:^0.0.20",
-        "tslib": "^2.5.2",
-        "web-streams-polyfill": "^4.0.0-beta.3"
+        "tslib": "^2.5.2"
     },
     "devDependencies": {
         "@jest/globals": "^29.5.0",
         "@yume-chan/eslint-config": "workspace:^1.0.0",
         "@yume-chan/tsconfig": "workspace:^1.0.0",
+        "@yume-chan/async": "^2.2.0",
+        "@yume-chan/struct": "workspace:^0.0.20",
         "cross-env": "^7.0.3",
         "eslint": "^8.41.0",
         "jest": "^29.5.0",
         "prettier": "^2.8.8",
         "ts-jest": "^29.0.4",
-        "typescript": "^5.0.3"
+        "typescript": "^5.0.3",
+        "web-streams-polyfill": "^4.0.0-beta.3"
+    },
+    "peerDependencies": {
+        "web-streams-polyfill": "^4.0.0-beta.3"
     }
 }


### PR DESCRIPTION
- fix: rollup build failed when imported `@yume-chan/stream-extra`.
- appearance
![image](https://github.com/yume-chan/ya-webadb/assets/49976933/a56031f9-39be-4566-af6b-ec0045f294e2)
- root cause: missing `peerDependencies` in package stream-extra.