### PR TITLE
feat(bin): rewrite Intent API and support all extra types

### DIFF
--- a/.changeset/tangy-trains-return.md
+++ b/.changeset/tangy-trains-return.md
@@ -1,0 +1,5 @@
+---
+"@yume-chan/android-bin": major
+---
+
+Removed `IntentBuilder`. APIs now takes `Intent`s using plain objects (with TypeScript typing)

--- a/libraries/android-bin/src/demo-mode.ts
+++ b/libraries/android-bin/src/demo-mode.ts
@@ -7,6 +7,7 @@
 import type { Adb } from "@yume-chan/adb";
 import { AdbServiceBase } from "@yume-chan/adb";
 
+import { ActivityManager } from "./am.js";
 import { Settings } from "./settings.js";
 
 export enum DemoModeSignalStrength {
@@ -52,10 +53,12 @@ export const DemoModeStatusBarModes = [
 export type DemoModeStatusBarMode = (typeof DemoModeStatusBarModes)[number];
 
 export class DemoMode extends AdbServiceBase {
+    #am: ActivityManager;
     #settings: Settings;
 
     constructor(adb: Adb) {
         super(adb);
+        this.#am = new ActivityManager(adb);
         this.#settings = new Settings(adb);
     }
 
@@ -108,27 +111,14 @@ export class DemoMode extends AdbServiceBase {
         }
     }
 
-    async broadcast(
-        command: string,
-        extra?: Record<string, string>,
-    ): Promise<void> {
-        const args = [
-            "am",
-            "broadcast",
-            "-a",
-            "com.android.systemui.demo",
-            "-e",
-            "command",
-            command,
-        ];
-
-        if (extra) {
-            for (const [key, value] of Object.entries(extra)) {
-                args.push("-e", key, value);
-            }
-        }
-
-        await this.adb.subprocess.noneProtocol.spawn(args).wait();
+    broadcast(command: string, extras?: Record<string, string>): Promise<void> {
+        return this.#am.broadcast({
+            action: "com.android.systemui.demo",
+            extras: {
+                command,
+                ...extras,
+            },
+        });
     }
 
     async setBatteryLevel(level: number): Promise<void> {

--- a/libraries/android-bin/src/demo-mode.ts
+++ b/libraries/android-bin/src/demo-mode.ts
@@ -56,9 +56,9 @@ export class DemoMode extends AdbServiceBase {
     #am: ActivityManager;
     #settings: Settings;
 
-    constructor(adb: Adb) {
+    constructor(adb: Adb, apiLevel?: number) {
         super(adb);
-        this.#am = new ActivityManager(adb);
+        this.#am = new ActivityManager(adb, apiLevel);
         this.#settings = new Settings(adb);
     }
 

--- a/libraries/android-bin/src/intent.spec.ts
+++ b/libraries/android-bin/src/intent.spec.ts
@@ -1,51 +1,57 @@
 import * as assert from "node:assert";
 import { describe, it } from "node:test";
 
-import { IntentBuilder } from "./intent.js";
+import { serializeIntent } from "./intent.js";
 
 describe("Intent", () => {
-    describe("IntentBuilder", () => {
+    describe("serializeIntent", () => {
         it("should set intent action", () => {
-            assert.deepStrictEqual(
-                new IntentBuilder().setAction("test_action").build(),
-                ["-a", "test_action"],
-            );
+            assert.deepStrictEqual(serializeIntent({ action: "test_action" }), [
+                "-a",
+                "test_action",
+            ]);
         });
 
         it("should set intent categories", () => {
             assert.deepStrictEqual(
-                new IntentBuilder()
-                    .addCategory("category_1")
-                    .addCategory("category_2")
-                    .build(),
+                serializeIntent({ categories: ["category_1", "category_2"] }),
                 ["-c", "category_1", "-c", "category_2"],
             );
         });
 
         it("should set intent package", () => {
-            assert.deepStrictEqual(
-                new IntentBuilder().setPackage("package_1").build(),
-                ["-p", "package_1"],
-            );
+            assert.deepStrictEqual(serializeIntent({ package: "package_1" }), [
+                "-p",
+                "package_1",
+            ]);
         });
 
         it("should set intent component", () => {
             assert.deepStrictEqual(
-                new IntentBuilder().setComponent("component_1").build(),
-                ["-n", "component_1"],
+                serializeIntent({
+                    component: {
+                        packageName: "package_1",
+                        className: "component_1",
+                    },
+                }),
+                ["-n", "package_1/component_1"],
             );
         });
 
         it("should set intent data", () => {
-            assert.deepStrictEqual(
-                new IntentBuilder().setData("data_1").build(),
-                ["-d", "data_1"],
-            );
+            assert.deepStrictEqual(serializeIntent({ data: "data_1" }), [
+                "-d",
+                "data_1",
+            ]);
         });
 
         it("should pass intent extras", () => {
             assert.deepStrictEqual(
-                new IntentBuilder().addStringExtra("key1", "value1").build(),
+                serializeIntent({
+                    extras: {
+                        key1: "value1",
+                    },
+                }),
                 ["--es", "key1", "value1"],
             );
         });

--- a/libraries/android-bin/src/intent.spec.ts
+++ b/libraries/android-bin/src/intent.spec.ts
@@ -5,28 +5,28 @@ import { serializeIntent } from "./intent.js";
 
 describe("Intent", () => {
     describe("serializeIntent", () => {
-        it("should set intent action", () => {
+        it("should serialize intent action", () => {
             assert.deepStrictEqual(serializeIntent({ action: "test_action" }), [
                 "-a",
                 "test_action",
             ]);
         });
 
-        it("should set intent categories", () => {
+        it("should serialize intent categories", () => {
             assert.deepStrictEqual(
                 serializeIntent({ categories: ["category_1", "category_2"] }),
                 ["-c", "category_1", "-c", "category_2"],
             );
         });
 
-        it("should set intent package", () => {
+        it("should serialize intent package", () => {
             assert.deepStrictEqual(serializeIntent({ package: "package_1" }), [
                 "-p",
                 "package_1",
             ]);
         });
 
-        it("should set intent component", () => {
+        it("should serialize intent component", () => {
             assert.deepStrictEqual(
                 serializeIntent({
                     component: {
@@ -38,22 +38,128 @@ describe("Intent", () => {
             );
         });
 
-        it("should set intent data", () => {
+        it("should serialize intent data", () => {
             assert.deepStrictEqual(serializeIntent({ data: "data_1" }), [
                 "-d",
                 "data_1",
             ]);
         });
 
-        it("should pass intent extras", () => {
-            assert.deepStrictEqual(
-                serializeIntent({
-                    extras: {
-                        key1: "value1",
-                    },
-                }),
-                ["--es", "key1", "value1"],
-            );
+        describe("extras", () => {
+            it("should serialize string extras", () => {
+                assert.deepStrictEqual(
+                    serializeIntent({
+                        extras: {
+                            key1: "value1",
+                        },
+                    }),
+                    ["--es", "key1", "value1"],
+                );
+            });
+
+            it("should serialize null extras", () => {
+                assert.deepStrictEqual(
+                    serializeIntent({
+                        extras: {
+                            key1: null,
+                        },
+                    }),
+                    ["--esn", "key1"],
+                );
+            });
+
+            it("should serialize integer extras", () => {
+                assert.deepStrictEqual(
+                    serializeIntent({
+                        extras: {
+                            key1: 1,
+                        },
+                    }),
+                    ["--ei", "key1", "1"],
+                );
+            });
+
+            it("should serialize URI extras", () => {
+                assert.deepStrictEqual(
+                    serializeIntent({
+                        extras: {
+                            key1: {
+                                type: "uri",
+                                value: "http://example.com",
+                            },
+                        },
+                    }),
+                    ["--eu", "key1", "http://example.com"],
+                );
+            });
+
+            it("should serialize component name", () => {
+                assert.deepStrictEqual(
+                    serializeIntent({
+                        extras: {
+                            key1: {
+                                packageName: "com.example.package_1",
+                                className: "com.example.component_1",
+                            },
+                        },
+                    }),
+                    [
+                        "--ecn",
+                        "key1",
+                        "com.example.package_1/com.example.component_1",
+                    ],
+                );
+            });
+
+            it("should serialize integer array extras", () => {
+                assert.deepStrictEqual(
+                    serializeIntent({
+                        extras: {
+                            key1: {
+                                type: "array",
+                                itemType: "int",
+                                value: [1, 2, 3],
+                            },
+                        },
+                    }),
+                    ["--eia", "key1", "1,2,3"],
+                );
+            });
+
+            it("should serialize integer array list extras", () => {
+                assert.deepStrictEqual(
+                    serializeIntent({
+                        extras: {
+                            key1: {
+                                type: "arrayList",
+                                itemType: "int",
+                                value: [1, 2, 3],
+                            },
+                        },
+                    }),
+                    ["--eial", "key1", "1,2,3"],
+                );
+            });
+
+            it("should serialize boolean extras", () => {
+                assert.deepStrictEqual(
+                    serializeIntent({
+                        extras: {
+                            key1: true,
+                        },
+                    }),
+                    ["--ez", "key1", "true"],
+                );
+
+                assert.deepStrictEqual(
+                    serializeIntent({
+                        extras: {
+                            key1: false,
+                        },
+                    }),
+                    ["--ez", "key1", "false"],
+                );
+            });
         });
     });
 });

--- a/libraries/android-bin/src/intent.ts
+++ b/libraries/android-bin/src/intent.ts
@@ -1,73 +1,267 @@
-export class IntentBuilder {
-    #action: string | undefined;
-    #categories: string[] = [];
-    #packageName: string | undefined;
-    #component: string | undefined;
-    #data: string | undefined;
-    #type: string | undefined;
-    #stringExtras = new Map<string, string>();
+// cspell: ignore eial
+// cspell: ignore elal
+// cspell: ignore efal
+// cspell: ignore esal
+// cspell: ignore edal
 
-    setAction(action: string): this {
-        this.#action = action;
-        return this;
+export interface IntentNumberExtra {
+    type: "long" | "float" | "double";
+    value: number;
+}
+
+export interface IntentStringExtra {
+    type: "uri";
+    value: string;
+}
+
+export interface IntentArrayListExtra {
+    type: "arrayList";
+    value: number[] | IntentNumberExtra[] | string[];
+}
+
+export interface ComponentName {
+    packageName: string;
+    className: string;
+}
+
+export interface Intent {
+    action?: string | undefined;
+    data?: string | undefined;
+    type?: string | undefined;
+    identifier?: string | undefined;
+    categories?: string[] | undefined;
+    extras?:
+        | Record<
+              string,
+              | string
+              | null
+              | number
+              | IntentStringExtra
+              | ComponentName
+              | number[]
+              | IntentArrayListExtra
+              | IntentNumberExtra
+              | IntentNumberExtra[]
+              | string[]
+              | boolean
+          >
+        | undefined;
+    flags?: number | undefined;
+    package?: string | undefined;
+    component?: ComponentName | undefined;
+}
+
+export function serializeIntent(intent: Intent) {
+    const result: string[] = [];
+
+    if (intent.action) {
+        result.push("-a", intent.action);
     }
 
-    addCategory(category: string): this {
-        this.#categories.push(category);
-        return this;
+    if (intent.data) {
+        result.push("-d", intent.data);
     }
 
-    setPackage(packageName: string): this {
-        this.#packageName = packageName;
-        return this;
+    if (intent.type) {
+        result.push("-t", intent.type);
     }
 
-    setComponent(component: string): this {
-        this.#component = component;
-        return this;
+    if (intent.identifier) {
+        result.push("-i", intent.identifier);
     }
 
-    setData(data: string): this {
-        this.#data = data;
-        return this;
-    }
-
-    addStringExtra(key: string, value: string): this {
-        this.#stringExtras.set(key, value);
-        return this;
-    }
-
-    build(): string[] {
-        const result: string[] = [];
-
-        if (this.#action) {
-            result.push("-a", this.#action);
-        }
-
-        for (const category of this.#categories) {
+    if (intent.categories) {
+        for (const category of intent.categories) {
             result.push("-c", category);
         }
-
-        if (this.#packageName) {
-            result.push("-p", this.#packageName);
-        }
-
-        if (this.#component) {
-            result.push("-n", this.#component);
-        }
-
-        if (this.#data) {
-            result.push("-d", this.#data);
-        }
-
-        if (this.#type) {
-            result.push("-t", this.#type);
-        }
-
-        for (const [key, value] of this.#stringExtras) {
-            result.push("--es", key, value);
-        }
-
-        return result;
     }
+
+    if (intent.extras) {
+        for (const [key, value] of Object.entries(intent.extras)) {
+            switch (typeof value) {
+                case "string":
+                    result.push("--es", key, value);
+                    break;
+                case "object":
+                    if (value === null) {
+                        result.push("--esn", key);
+                        break;
+                    }
+
+                    if (Array.isArray(value)) {
+                        if (value.length === 0) {
+                            throw new Error(
+                                "Intent extra array cannot be empty",
+                            );
+                        }
+
+                        switch (typeof value[0]) {
+                            case "number":
+                                result.push(
+                                    "--eia",
+                                    key,
+                                    (value as number[]).join(","),
+                                );
+                                break;
+                            case "object":
+                                switch (value[0].type) {
+                                    case "long":
+                                        result.push(
+                                            "--ela",
+                                            key,
+                                            (value as IntentNumberExtra[])
+                                                .map((item) => item.value)
+                                                .join(","),
+                                        );
+                                        break;
+                                    case "float":
+                                        result.push(
+                                            "--efa",
+                                            key,
+                                            (value as IntentNumberExtra[])
+                                                .map((item) => item.value)
+                                                .join(","),
+                                        );
+                                        break;
+                                    case "double":
+                                        result.push(
+                                            "--eda",
+                                            key,
+                                            (value as IntentNumberExtra[])
+                                                .map((item) => item.value)
+                                                .join(","),
+                                        );
+                                        break;
+                                }
+                                break;
+                            case "string":
+                                result.push(
+                                    "--esa",
+                                    key,
+                                    (value as string[])
+                                        .map((item) =>
+                                            item.replaceAll(",", "\\,"),
+                                        )
+                                        .join(","),
+                                );
+                                break;
+                        }
+                        break;
+                    }
+
+                    if ("packageName" in value) {
+                        result.push(
+                            "---ecn",
+                            key,
+                            value.packageName + "/" + value.className,
+                        );
+                        break;
+                    }
+
+                    switch (value.type) {
+                        case "uri":
+                            result.push("--eu", key, value.value);
+                            break;
+                        case "arrayList":
+                            if (value.value.length === 0) {
+                                throw new Error(
+                                    "Intent extra array cannot be empty",
+                                );
+                            }
+
+                            switch (typeof value.value[0]) {
+                                case "number":
+                                    result.push(
+                                        "--eial",
+                                        key,
+                                        (value.value as number[]).join(","),
+                                    );
+                                    break;
+                                case "object":
+                                    switch (value.value[0].type) {
+                                        case "long":
+                                            result.push(
+                                                "--elal",
+                                                key,
+                                                (
+                                                    value.value as IntentNumberExtra[]
+                                                )
+                                                    .map((item) => item.value)
+                                                    .join(","),
+                                            );
+                                            break;
+                                        case "float":
+                                            result.push(
+                                                "--efal",
+                                                key,
+                                                (
+                                                    value.value as IntentNumberExtra[]
+                                                )
+                                                    .map((item) => item.value)
+                                                    .join(","),
+                                            );
+                                            break;
+                                        case "double":
+                                            result.push(
+                                                "--edal",
+                                                key,
+                                                (
+                                                    value.value as IntentNumberExtra[]
+                                                )
+                                                    .map((item) => item.value)
+                                                    .join(","),
+                                            );
+                                            break;
+                                    }
+                                    break;
+                                case "string":
+                                    result.push(
+                                        "--esal",
+                                        key,
+                                        (value.value as string[])
+                                            .map((item) =>
+                                                item.replaceAll(",", "\\,"),
+                                            )
+                                            .join(","),
+                                    );
+                                    break;
+                            }
+                            break;
+                        case "long":
+                            result.push("--el", key, value.value.toString());
+                            break;
+                        case "float":
+                            result.push("--ef", key, value.value.toString());
+                            break;
+                        case "double":
+                            result.push("--ed", key, value.value.toString());
+                            break;
+                    }
+                    break;
+                case "number":
+                    result.push("--ei", key, value.toString());
+                    break;
+                case "boolean":
+                    result.push("--ez", key, value ? "true" : "false");
+                    break;
+            }
+        }
+    }
+
+    if (intent.component) {
+        result.push(
+            "-n",
+            intent.component.packageName + "/" + intent.component.className,
+        );
+    }
+
+    if (intent.package) {
+        result.push("-p", intent.package);
+    }
+
+    if (intent.flags) {
+        result.push("-f", intent.flags.toString());
+    }
+
+    return result;
 }

--- a/libraries/android-bin/src/intent.ts
+++ b/libraries/android-bin/src/intent.ts
@@ -184,6 +184,8 @@ export function serializeIntent(intent: Intent) {
         result.push("-p", intent.package);
     }
 
+    // `0` is the default value for `flags` when deserializing
+    // so it can be omitted if it's either `undefined` or `0`
     if (intent.flags) {
         result.push("-f", intent.flags.toString());
     }

--- a/libraries/android-bin/src/pm.ts
+++ b/libraries/android-bin/src/pm.ts
@@ -486,7 +486,7 @@ export class PackageManager extends AdbServiceBase {
 
         command.push(packageName);
 
-        // `cmd package` doesn't support `path` command on Android 7 and 8.
+        // Android 7 and 8 support `cmd package` but not `cmd package path` command
         let process: AdbNoneProtocolProcess;
         if (this.#apiLevel !== undefined && this.#apiLevel <= 27) {
             command[0] = PackageManager.CommandName;
@@ -670,9 +670,9 @@ export class PackageManager extends AdbServiceBase {
             sessionId.toString(),
         ];
 
-        // `cmd package` does support `install-commit` command on Android 7,
-        // but the "Success" message is not forwarded back to the client,
-        // causing this function to fail with an empty message.
+        // Android 7 did support `cmd package install-commit` command,
+        // but it wrote the "Success" message to an incorrect output stream,
+        // causing `checkResult` to fail with an empty message
         let process: AdbNoneProtocolProcess;
         if (this.#apiLevel !== undefined && this.#apiLevel <= 25) {
             command[0] = PackageManager.CommandName;

--- a/libraries/android-bin/src/pm.ts
+++ b/libraries/android-bin/src/pm.ts
@@ -14,7 +14,8 @@ import {
 } from "@yume-chan/stream-extra";
 
 import { Cmd } from "./cmd/index.js";
-import type { IntentBuilder } from "./intent.js";
+import type { Intent } from "./intent.js";
+import { serializeIntent } from "./intent.js";
 import type { Optional, SingleUserOrAll } from "./utils.js";
 import { buildCommand } from "./utils.js";
 
@@ -178,7 +179,7 @@ const PACKAGE_MANAGER_UNINSTALL_OPTIONS_MAP: Record<
 
 export interface PackageManagerResolveActivityOptions {
     user?: SingleUserOrAll;
-    intent: IntentBuilder;
+    intent: Intent;
 }
 
 const PACKAGE_MANAGER_RESOLVE_ACTIVITY_OPTIONS_MAP: Partial<
@@ -551,7 +552,7 @@ export class PackageManager extends AdbServiceBase {
             PACKAGE_MANAGER_RESOLVE_ACTIVITY_OPTIONS_MAP,
         );
 
-        for (const arg of options.intent.build()) {
+        for (const arg of serializeIntent(options.intent)) {
             command.push(arg);
         }
 


### PR DESCRIPTION
Using plain object (and object literals) to represent `Intent`s feels more natural in JavaScript type system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a broadcast API to send system broadcasts with optional user targeting and receiver permission.
  - Demo Mode broadcasting now uses the unified broadcast API and always includes command data.

- Refactor
  - Replaced builder-style intents with a typed plain-object intent model and a serialize-to-flags flow, expanding supported extras (strings, numbers, booleans, URIs, arrays).
  - Activity launch/resolve flows and constructors updated to accept the new intent format and optional API-level handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->