### PR TITLE
fix(struct): fix some overloads of `buffer` ignores specified value converter

### DIFF
--- a/.changeset/sweet-teams-chew.md
+++ b/.changeset/sweet-teams-chew.md
@@ -1,0 +1,5 @@
+---
+"@yume-chan/struct": patch
+---
+
+Fix an issue that some overloads of `buffer` (and `string`) ignores specified value converter

--- a/libraries/adb/src/commands/reverse.spec.ts
+++ b/libraries/adb/src/commands/reverse.spec.ts
@@ -1,0 +1,19 @@
+import * as assert from "node:assert";
+import { describe, it } from "node:test";
+
+import { encodeUtf8, Uint8ArrayExactReadable } from "@yume-chan/struct";
+import { AdbReverseErrorResponse } from "./reverse.js";
+
+describe("AdbReverseErrorResponse", () => {
+    it("should throw AdbReverseNotSupportedError", () => {
+        assert.throws(
+            () =>
+                AdbReverseErrorResponse.deserialize(
+                    new Uint8ArrayExactReadable(
+                        encodeUtf8("001Dmore than one device/emulator"),
+                    ),
+                ),
+            /ADB reverse tunnel is not supported on this device when connected wirelessly./,
+        );
+    });
+});

--- a/libraries/adb/src/commands/reverse.ts
+++ b/libraries/adb/src/commands/reverse.ts
@@ -52,7 +52,7 @@ export class AdbReverseNotSupportedError extends AdbReverseError {
     }
 }
 
-const AdbReverseErrorResponse = extend(
+export const AdbReverseErrorResponse = extend(
     AdbReverseStringResponse,
     {},
     {

--- a/libraries/struct/src/string.spec.ts
+++ b/libraries/struct/src/string.spec.ts
@@ -1,0 +1,16 @@
+import * as assert from "node:assert";
+import { describe, it } from "node:test";
+
+import { string } from "./string.js";
+import { Uint8ArrayExactReadable } from "./readable.js";
+
+describe("string", () => {
+    it("should decode buffer as UTF-8", () => {
+        const buffer = new Uint8Array([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+        const result = string(buffer.length).deserialize(
+            new Uint8ArrayExactReadable(buffer),
+            { dependencies: {} as never, littleEndian: true },
+        );
+        assert.strictEqual(result, "hello");
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain buffer and string operations were not respecting the specified value converter settings.

* **Tests**
  * Added test coverage for error handling in reverse connection scenarios.
  * Added test coverage for string decoding from buffer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->