### PR TITLE
Fix scrcpy startup on Android 7.0 and below by using CLASSPATH

### DIFF
--- a/libraries/adb-scrcpy/src/client.ts
+++ b/libraries/adb-scrcpy/src/client.ts
@@ -133,11 +133,13 @@ export class AdbScrcpyClient<TOptions extends AdbScrcpyOptions<object>> {
                 }
             }
 
+            // Use environment variable CLASSPATH instead of -cp flag
+            // This is the approach used by the official scrcpy C implementation
+            // See: https://github.com/Genymobile/scrcpy/blob/master/app/src/server.c
             const args = [
+                `CLASSPATH=${path}`, // Set environment variable
                 "app_process",
-                "-cp",
-                path,
-                /* unused */ "/",
+                "/", // Parent dir (unused but required)
                 "com.genymobile.scrcpy.Server",
                 options.version,
                 ...options.serialize(),


### PR DESCRIPTION
This PR fixes an issue where the scrcpy server fails to start on Android 7.0 (API 24) and lower versions.

Instead of passing the classpath via the -cp command-line argument, this change sets the CLASSPATH environment variable when invoking app_process. This implementation aligns with the official scrcpy C client and resolves compatibility issues with app_process on older Android versions.

Changes:

Replaced -cp <path> usage with CLASSPATH=<path> environment variable for app_process execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Scrcpy server versions 3.3.2 and 3.3.3

* **Bug Fixes**
  * Fixed device removal event handling
  * Fixed default version configuration for recent client versions

* **Chores**
  * Updated development dependencies including TypeScript, Node types, and build tooling across all packages
  * Updated package versions to reflect new feature releases

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->