### PR TITLE
fix(adb-server-node-tcp): bypass the `AbortSignal` to `Socket`

### DIFF
--- a/.changeset/floppy-moose-cough.md
+++ b/.changeset/floppy-moose-cough.md
@@ -1,0 +1,5 @@
+---
+"@yume-chan/adb-server-node-tcp": patch
+---
+
+Close the underlying socket when the connection is aborted.

--- a/libraries/adb-server-node-tcp/src/index.ts
+++ b/libraries/adb-server-node-tcp/src/index.ts
@@ -73,9 +73,9 @@ export class AdbServerNodeTcpConnector
     }
 
     async connect(
-        { unref }: AdbServerClient.ServerConnectionOptions = { unref: false },
+        { unref, signal }: AdbServerClient.ServerConnectionOptions = { unref: false },
     ): Promise<AdbServerClient.ServerConnection> {
-        const socket = new Socket();
+        const socket = new Socket({ signal: signal as globalThis.AbortSignal });
         if (unref) {
             socket.unref();
         }


### PR DESCRIPTION
Close the underlying `Socket` to avoid leaking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved socket connection cleanup by ensuring the underlying socket is properly closed when a connection is aborted, enhancing resource management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->