### PR TITLE
refactor(decoder): unify decoder and renderer types

### DIFF
--- a/libraries/scrcpy-decoder-tinyh264/src/decoder.ts
+++ b/libraries/scrcpy-decoder-tinyh264/src/decoder.ts
@@ -36,13 +36,17 @@ export class TinyH264Decoder implements ScrcpyVideoDecoder {
             },
         };
 
+    get type() {
+        return "software" as const;
+    }
+
     #canvas: HTMLCanvasElement | OffscreenCanvas;
     get canvas() {
         return this.#canvas;
     }
 
     #renderer: YuvCanvas | undefined;
-    #rendererType: "2d" | "webgl";
+    #rendererType: "software" | "hardware";
     get rendererType() {
         return this.#rendererType;
     }
@@ -116,7 +120,7 @@ export class TinyH264Decoder implements ScrcpyVideoDecoder {
             // so we implement our own check here
             webGL: webGlSupported,
         });
-        this.#rendererType = webGlSupported ? "webgl" : "2d";
+        this.#rendererType = webGlSupported ? "hardware" : "software";
 
         void this.#pause.readable
             .pipeTo(

--- a/libraries/scrcpy-decoder-tinyh264/src/types.ts
+++ b/libraries/scrcpy-decoder-tinyh264/src/types.ts
@@ -68,6 +68,10 @@ export interface ScrcpyVideoDecoder
         ScrcpyVideoDecoderPauseController,
         ScrcpyVideoSize,
         Disposable {
+    readonly type: "software" | "hardware";
+
+    readonly rendererType: "software" | "hardware";
+
     readonly writable: WritableStream<ScrcpyMediaStreamPacket>;
 }
 

--- a/libraries/scrcpy-decoder-webcodecs/src/video/decoder.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/decoder.ts
@@ -34,6 +34,11 @@ export class WebCodecsVideoDecoder implements ScrcpyVideoDecoder {
 
     // #region parameters
 
+    #type: "software" | "hardware";
+    get type() {
+        return this.#type;
+    }
+
     #codec: ScrcpyVideoCodecId;
     get codec() {
         return this.#codec;
@@ -42,6 +47,10 @@ export class WebCodecsVideoDecoder implements ScrcpyVideoDecoder {
     #renderer: VideoFrameRenderer;
     get renderer() {
         return this.#renderer;
+    }
+
+    get rendererType() {
+        return this.#renderer.type;
     }
 
     // #endregion parameters
@@ -152,6 +161,10 @@ export class WebCodecsVideoDecoder implements ScrcpyVideoDecoder {
         hardwareAcceleration = "no-preference",
         optimizeForLatency = true,
     }: WebCodecsVideoDecoder.Options) {
+        this.#type =
+            hardwareAcceleration !== "prefer-software"
+                ? "hardware"
+                : "software";
         this.#codec = codec;
         this.#renderer = renderer;
 

--- a/libraries/scrcpy-decoder-webcodecs/src/video/render/auto-canvas.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/render/auto-canvas.ts
@@ -6,9 +6,8 @@ import { WebGLVideoFrameRenderer } from "./webgl.js";
 export class AutoCanvasRenderer implements VideoFrameRenderer {
     #inner: CanvasVideoFrameRenderer;
 
-    #type: "bitmap" | "webgl";
     get type() {
-        return this.#type;
+        return this.#inner.type;
     }
 
     get canvas() {
@@ -19,16 +18,11 @@ export class AutoCanvasRenderer implements VideoFrameRenderer {
         return this.#inner.writable;
     }
 
-    constructor(
-        canvas?: HTMLCanvasElement | OffscreenCanvas,
-        options?: WebGLVideoFrameRenderer.Options,
-    ) {
+    constructor(options?: WebGLVideoFrameRenderer.Options) {
         if (WebGLVideoFrameRenderer.isSupported) {
-            this.#inner = new WebGLVideoFrameRenderer(canvas, options);
-            this.#type = "webgl";
+            this.#inner = new WebGLVideoFrameRenderer(options);
         } else {
-            this.#inner = new BitmapVideoFrameRenderer(canvas, options);
-            this.#type = "bitmap";
+            this.#inner = new BitmapVideoFrameRenderer(options);
         }
     }
 

--- a/libraries/scrcpy-decoder-webcodecs/src/video/render/bitmap.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/render/bitmap.ts
@@ -1,21 +1,18 @@
 import { CanvasVideoFrameRenderer } from "./canvas.js";
 
 export class BitmapVideoFrameRenderer extends CanvasVideoFrameRenderer {
+    override get type() {
+        return "software" as const;
+    }
+
     #context: ImageBitmapRenderingContext;
 
-    constructor(
-        canvas?: HTMLCanvasElement | OffscreenCanvas,
-        options?: CanvasVideoFrameRenderer.Options,
-    ) {
-        super(
-            async (frame) => {
-                const bitmap = await createImageBitmap(frame);
-                this.#context.transferFromImageBitmap(bitmap);
-                bitmap.close();
-            },
-            canvas,
-            options,
-        );
+    constructor(options?: CanvasVideoFrameRenderer.Options) {
+        super(async (frame) => {
+            const bitmap = await createImageBitmap(frame);
+            this.#context.transferFromImageBitmap(bitmap);
+            bitmap.close();
+        }, options);
 
         const context = (this.canvas as HTMLCanvasElement).getContext(
             "bitmaprenderer",

--- a/libraries/scrcpy-decoder-webcodecs/src/video/render/canvas.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/render/canvas.ts
@@ -11,6 +11,8 @@ export abstract class CanvasVideoFrameRenderer<
     TOptions extends CanvasVideoFrameRenderer.Options =
         CanvasVideoFrameRenderer.Options,
 > implements VideoFrameRenderer {
+    abstract get type(): "software" | "hardware";
+
     #canvas: HTMLCanvasElement | OffscreenCanvas;
     get canvas() {
         return this.#canvas;
@@ -47,11 +49,10 @@ export abstract class CanvasVideoFrameRenderer<
 
     constructor(
         draw: (frame: VideoFrame) => MaybePromiseLike<undefined>,
-        canvas?: HTMLCanvasElement | OffscreenCanvas,
         options?: TOptions,
     ) {
         this.#draw = draw;
-        this.#canvas = canvas ?? createCanvas();
+        this.#canvas = options?.canvas ?? createCanvas();
         this.#options = options;
         this.#canvasSize = options?.canvasSize ?? "video";
 
@@ -151,6 +152,8 @@ export abstract class CanvasVideoFrameRenderer<
 
 export namespace CanvasVideoFrameRenderer {
     export interface Options {
+        canvas?: HTMLCanvasElement | OffscreenCanvas;
+
         /**
          * Whether to update the canvas size (rendering resolution) automatically.
          *

--- a/libraries/scrcpy-decoder-webcodecs/src/video/render/insertable-stream.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/render/insertable-stream.ts
@@ -15,6 +15,10 @@ export class InsertableStreamVideoFrameRenderer implements VideoFrameRenderer {
         return typeof MediaStreamTrackGenerator !== "undefined";
     }
 
+    get type() {
+        return "hardware" as const;
+    }
+
     #element: HTMLVideoElement;
     get element() {
         return this.#element;

--- a/libraries/scrcpy-decoder-webcodecs/src/video/render/type.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/render/type.ts
@@ -2,7 +2,9 @@ import type { MaybePromiseLike } from "@yume-chan/async";
 import type { WritableStream } from "@yume-chan/stream-extra";
 
 export interface VideoFrameRenderer {
-    writable: WritableStream<VideoFrame>;
+    readonly type: "software" | "hardware";
+
+    readonly writable: WritableStream<VideoFrame>;
 
     snapshot?(options?: ImageEncodeOptions): Promise<Blob | undefined>;
 

--- a/libraries/scrcpy-decoder-webcodecs/src/video/render/webgl.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/render/webgl.ts
@@ -160,6 +160,10 @@ export class WebGLVideoFrameRenderer extends CanvasVideoFrameRenderer<WebGLVideo
         });
     }
 
+    override get type() {
+        return "hardware" as const;
+    }
+
     #context: WebGLRenderingContext;
     #program!: WebGLProgram;
     #vertexBuffer!: WebGLBuffer;
@@ -174,50 +178,38 @@ export class WebGLVideoFrameRenderer extends CanvasVideoFrameRenderer<WebGLVideo
      * Whether to allow capturing the canvas content using APIs like `readPixels` and `toDataURL`.
      * Enable this option may reduce performance.
      */
-    constructor(
-        canvas?: HTMLCanvasElement | OffscreenCanvas,
-        options?: WebGLVideoFrameRenderer.Options,
-    ) {
-        super(
-            (frame): undefined => {
-                const gl = this.#context;
-                if (gl.isContextLost()) {
-                    return;
-                }
+    constructor(options?: WebGLVideoFrameRenderer.Options) {
+        super((frame): undefined => {
+            const gl = this.#context;
+            if (gl.isContextLost()) {
+                return;
+            }
 
-                gl.texImage2D(
-                    gl.TEXTURE_2D,
-                    0,
-                    gl.RGBA,
-                    gl.RGBA,
-                    gl.UNSIGNED_BYTE,
-                    frame,
-                );
+            gl.texImage2D(
+                gl.TEXTURE_2D,
+                0,
+                gl.RGBA,
+                gl.RGBA,
+                gl.UNSIGNED_BYTE,
+                frame,
+            );
 
-                gl.uniform2f(
-                    this.#texelSizeLocation,
-                    1.0 / frame.codedWidth,
-                    1.0 / frame.codedHeight,
-                );
+            gl.uniform2f(
+                this.#texelSizeLocation,
+                1.0 / frame.codedWidth,
+                1.0 / frame.codedHeight,
+            );
 
-                gl.uniform1f(
-                    this.#zoomLocation,
-                    this.canvas.width / frame.codedWidth,
-                );
+            gl.uniform1f(
+                this.#zoomLocation,
+                this.canvas.width / frame.codedWidth,
+            );
 
-                gl.viewport(
-                    0,
-                    0,
-                    gl.drawingBufferWidth,
-                    gl.drawingBufferHeight,
-                );
-                gl.drawArrays(gl.TRIANGLES, 0, 3);
+            gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
+            gl.drawArrays(gl.TRIANGLES, 0, 3);
 
-                gl.flush();
-            },
-            canvas,
-            options,
-        );
+            gl.flush();
+        }, options);
 
         const gl = glCreateContext(this.canvas, {
             // Low-power GPU should be enough for video rendering.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Decoders and renderers now expose their implementation type (software or hardware) via public getters, allowing applications to query which implementation is active.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->