### PR TITLE
feat: add brand check for instanceof

### DIFF
--- a/libraries/adb-credential-web/package.json
+++ b/libraries/adb-credential-web/package.json
@@ -32,6 +32,7 @@
     "dependencies": {
         "@yume-chan/adb": "workspace:^",
         "@yume-chan/async": "^4.1.3",
+        "@yume-chan/stream-extra": "workspace:^",
         "@yume-chan/struct": "workspace:^"
     },
     "devDependencies": {

--- a/libraries/adb-credential-web/src/storage/prf/storage.ts
+++ b/libraries/adb-credential-web/src/storage/prf/storage.ts
@@ -1,4 +1,6 @@
-import { toLocalUint8Array, type MaybeError } from "@yume-chan/adb";
+import type { MaybeError } from "@yume-chan/adb";
+import { toLocalUint8Array } from "@yume-chan/adb";
+import { toUint8Array } from "@yume-chan/stream-extra";
 import {
     buffer,
     struct,
@@ -44,13 +46,6 @@ async function deriveAesKey(
         false,
         ["encrypt", "decrypt"],
     );
-}
-
-function toUint8Array(source: BufferSource) {
-    if (source instanceof ArrayBuffer) {
-        return new Uint8Array(source);
-    }
-    return new Uint8Array(source.buffer, source.byteOffset, source.byteLength);
 }
 
 const Bundle = struct(

--- a/libraries/adb-scrcpy/src/client.ts
+++ b/libraries/adb-scrcpy/src/client.ts
@@ -57,7 +57,19 @@ function concatStreams<T>(...streams: ReadableStream<T>[]): ReadableStream<T> {
     });
 }
 
+export const AdbScrcpyExitedErrorBrand = Symbol.for(
+    "AdbScrcpyExitedError.brand",
+);
+
 export class AdbScrcpyExitedError extends Error {
+    [AdbScrcpyExitedErrorBrand] = true;
+
+    static override [Symbol.hasInstance](value: unknown) {
+        return !!(value as AdbScrcpyExitedError | undefined)?.[
+            AdbScrcpyExitedErrorBrand
+        ];
+    }
+
     output: readonly string[];
 
     constructor(output: readonly string[]) {

--- a/libraries/adb/src/commands/reverse.ts
+++ b/libraries/adb/src/commands/reverse.ts
@@ -44,7 +44,19 @@ export class AdbReverseError extends Error {
     }
 }
 
+const AdbReverseNotSupportedErrorBrand = Symbol.for(
+    "AdbReverseNotSupportedError.brand",
+);
+
 export class AdbReverseNotSupportedError extends AdbReverseError {
+    [AdbReverseNotSupportedErrorBrand] = true;
+
+    static override [Symbol.hasInstance](value: unknown) {
+        return !!(value as AdbReverseNotSupportedError | undefined)?.[
+            AdbReverseNotSupportedErrorBrand
+        ];
+    }
+
     constructor() {
         super(
             "ADB reverse tunnel is not supported on this device when connected wirelessly.",

--- a/libraries/stream-extra/src/consumable.ts
+++ b/libraries/stream-extra/src/consumable.ts
@@ -14,11 +14,19 @@ import {
 import type { Task } from "./task.js";
 import { createTask } from "./task.js";
 
+const Brand = Symbol.for("Consumable.brand");
+
 export class Consumable<T> {
     static readonly WritableStream = ConsumableWritableStream;
     static readonly WrapWritableStream = ConsumableWrapWritableStream;
     static readonly ReadableStream = ConsumableReadableStream;
     static readonly WrapByteReadableStream = ConsumableWrapByteReadableStream;
+
+    readonly [Brand] = true;
+
+    static [Symbol.hasInstance](value: unknown) {
+        return !!(value as Consumable<unknown> | undefined)?.[Brand];
+    }
 
     readonly #task: Task;
     readonly #resolver: PromiseResolver<void>;

--- a/libraries/struct/src/readable.ts
+++ b/libraries/struct/src/readable.ts
@@ -2,7 +2,19 @@
 
 import type { MaybePromiseLike } from "@yume-chan/async";
 
+const ExactReadableEndedErrorBrand = Symbol.for(
+    "ExactReadableEndedError.brand",
+);
+
 export class ExactReadableEndedError extends Error {
+    [ExactReadableEndedErrorBrand] = true;
+
+    static override [Symbol.hasInstance](value: unknown) {
+        return !!(value as ExactReadableEndedError | undefined)?.[
+            ExactReadableEndedErrorBrand
+        ];
+    }
+
     constructor() {
         super("ExactReadable ended");
     }

--- a/libraries/struct/src/struct.ts
+++ b/libraries/struct/src/struct.ts
@@ -57,7 +57,17 @@ export class StructNotEnoughDataError extends StructDeserializeError {
     }
 }
 
+const StructEmptyErrorBrand = Symbol.for("StructEmptyError.brand");
+
 export class StructEmptyError extends StructDeserializeError {
+    [StructEmptyErrorBrand] = true;
+
+    static override [Symbol.hasInstance](value: unknown) {
+        return !!(value as StructEmptyError | undefined)?.[
+            StructEmptyErrorBrand
+        ];
+    }
+
     constructor() {
         super("The underlying readable doesn't contain any more struct");
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       '@yume-chan/async':
         specifier: ^4.1.3
         version: 4.1.3
+      '@yume-chan/stream-extra':
+        specifier: workspace:^
+        version: link:../stream-extra
       '@yume-chan/struct':
         specifier: workspace:^
         version: link:../struct


### PR DESCRIPTION
Make sure `instanceof` work for object from another realm or another copy of the module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced specialized error types for improved error handling: InvalidKeyError, VendorKeyError, AdbReverseNotSupportedError, ExactReadableEndedError, and StructEmptyError
  * Exposed error types publicly for external reference

* **Refactor**
  * Standardized error wrapping and identification across libraries
  * Extracted utility functions to external dependencies

* **Chores**
  * Added @yume-chan/stream-extra dependency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->