### PR TITLE
feat: Add connection state to AdbBanner

### DIFF
--- a/libraries/adb/src/banner.spec.ts
+++ b/libraries/adb/src/banner.spec.ts
@@ -8,6 +8,7 @@ describe("AdbBanner", () => {
         const banner = AdbBanner.parse(
             "device::ro.product.name=NovaPro;ro.product.model=NovaPro;ro.product.device=NovaPro;\0",
         );
+        assert.strictEqual(banner.state, "device");
         assert.strictEqual(banner.product, "NovaPro");
         assert.strictEqual(banner.model, "NovaPro");
         assert.strictEqual(banner.device, "NovaPro");
@@ -18,6 +19,7 @@ describe("AdbBanner", () => {
         const banner = AdbBanner.parse(
             "device::ro.product.name=mblu_10_CN;ro.product.model=mblu10;ro.product.device=mblu10;features=sendrecv_v2_brotli,remount_shell,sendrecv_v2,abb_exec,fixed_push_mkdir,fixed_push_symlink_timestamp,abb,shell_v2,cmd,ls_v2,apex,stat_v2",
         );
+        assert.strictEqual(banner.state, "device");
         assert.strictEqual(banner.product, "mblu_10_CN");
         assert.strictEqual(banner.model, "mblu10");
         assert.strictEqual(banner.device, "mblu10");

--- a/libraries/adb/src/banner.ts
+++ b/libraries/adb/src/banner.ts
@@ -1,4 +1,5 @@
 import type { AdbFeature } from "./features.js";
+import type { AdbServerClient } from "./server/client.js";
 
 export const AdbBannerKey = {
     Product: "ro.product.name",
@@ -11,6 +12,7 @@ export type AdbBannerKey = (typeof AdbBannerKey)[keyof typeof AdbBannerKey];
 
 export class AdbBanner {
     static parse(banner: string) {
+        let state: AdbServerClient.ConnectionState | undefined;
         let product: string | undefined;
         let model: string | undefined;
         let device: string | undefined;
@@ -18,6 +20,9 @@ export class AdbBanner {
 
         const pieces = banner.split("::");
         if (pieces.length > 1) {
+            state = (pieces[0]!.trim() || undefined) as
+                | AdbServerClient.ConnectionState
+                | undefined;
             const props = pieces[1]!;
             for (const prop of props.split(";")) {
                 // istanbul ignore if
@@ -48,7 +53,12 @@ export class AdbBanner {
             }
         }
 
-        return new AdbBanner(product, model, device, features);
+        return new AdbBanner(state, product, model, device, features);
+    }
+
+    readonly #state: AdbServerClient.ConnectionState | undefined;
+    get state() {
+        return this.#state;
     }
 
     readonly #product: string | undefined;
@@ -71,12 +81,15 @@ export class AdbBanner {
         return this.#features;
     }
 
+    // eslint-disable-next-line @typescript-eslint/max-params
     constructor(
+        state: AdbServerClient.ConnectionState | undefined,
         product: string | undefined,
         model: string | undefined,
         device: string | undefined,
         features: readonly AdbFeature[],
     ) {
+        this.#state = state;
         this.#product = product;
         this.#model = model;
         this.#device = device;

--- a/libraries/adb/src/server/client.ts
+++ b/libraries/adb/src/server/client.ts
@@ -482,6 +482,7 @@ export class AdbServerClient {
         );
 
         const banner = new AdbBanner(
+            info?.state,
             info?.product,
             info?.model,
             info?.device,


### PR DESCRIPTION
This allows Non AdbServerClient devices to see the actual connection state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Banner metadata now includes device connection state so interfaces can read the current connection status.

* **Tests**
  * Updated tests to assert that parsed banner state matches the expected connection state for provided fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->