### PR TITLE
fix(adb): use one-shot format in getDeviceFeatures for multi-device support

### DIFF
--- a/libraries/adb/src/server/client.ts
+++ b/libraries/adb/src/server/client.ts
@@ -289,34 +289,51 @@ export class AdbServerClient {
     async getDeviceFeatures(
         device: AdbServerClient.DeviceSelector,
     ): Promise<{ transportId: bigint; features: readonly AdbFeature[] }> {
-        // On paper, `host:features` is a host service (device features are cached in host),
-        // so it shouldn't use `createDeviceConnection`,
-        // which is used to forward the service to the device.
+        // Use one-shot format (e.g. `host-serial:S:features` or
+        // `host-transport-id:N:features`) instead of the two-step protocol
+        // (`host:transport-id:N` then `host:features`).
         //
-        // However, `createDeviceConnection` is a two step process:
-        //
-        //    1. Send a switch device service to host, to switch the connection to the device.
-        //    2. Send the actual service to host, let it forward the service to the device.
-        //
-        // In step 2, the host only forward the service to device if the service is unknown to host.
-        // If the service is a host service, it's still handled by host.
-        //
-        // Even better, if the service needs a device selector, but the selector is not provided,
-        // the service will be executed against the device selected by the switch device service.
-        // So we can use all device selector formats for the host service,
-        // and get the transport ID in the same time.
-        const connection = await this.createDeviceConnection(
+        // The two-step protocol fails in multi-device environments because
+        // ADB server does not inherit the device context for host-level
+        // services (like `host:features`) after a transport switch command.
+        // Device-level services (shell, sync, reverse) work after the switch,
+        // but `host:features` still requires an explicit device qualifier.
+        const service = AdbServerClient.formatDeviceService(
             device,
-            "host:features",
+            "features",
         );
-        // Luckily `AdbServerClient.Socket` is compatible with `AdbServerClient.ServerConnection`
-        const dataConnection = new AdbServerDataConnection(connection);
+        const connection = await this.createConnection(service);
         try {
-            const featuresString = await dataConnection.readString();
+            const featuresString = await connection.readString();
             const features = featuresString.split(",") as AdbFeature[];
-            return { transportId: connection.transportId, features };
+
+            let transportId: bigint;
+            if (device && "transportId" in device) {
+                transportId = device.transportId;
+            } else {
+                const devices = await this.getDevices();
+                if (device && "serial" in device) {
+                    const info = devices.find(
+                        (d) => d.serial === device.serial,
+                    );
+                    if (!info) {
+                        throw new Error(
+                            `Device with serial ${device.serial} not found`,
+                        );
+                    }
+                    transportId = info.transportId;
+                } else if (devices.length === 1) {
+                    transportId = devices[0]!.transportId;
+                } else {
+                    throw new Error(
+                        "Cannot determine transport ID: multiple devices connected and no specific device selected",
+                    );
+                }
+            }
+
+            return { transportId, features };
         } finally {
-            await dataConnection.dispose();
+            await connection.dispose();
         }
     }
 


### PR DESCRIPTION
## Summary

`AdbServerClient.getDeviceFeatures()` fails with `"more than one device/emulator"` when multiple Android devices are connected to the host machine.

## Root Cause

The current implementation uses a two-step protocol:
1. Send transport switch: `host:transport-id:N` → OKAY
2. Send service: `host:features` → **FAIL "more than one device/emulator"**

After a transport switch, **device-level** services (`shell:`, `sync:`, `reverse:`) are correctly forwarded to the switched device. However, **host-level** services like `host:features` still require an explicit device qualifier — the ADB server does not inherit the device context for host services.

## Protocol-Level Verification

Tested directly against ADB server (version 37.0.0, protocol 41):

```
# Two-step protocol (FAILS with multiple devices):
Send: host:transport-id:270 → OKAY
Send: host:features → FAIL "more than one device/emulator"

# One-shot format (WORKS):
Send: host-transport-id:270:features → OKAY + features ✅
Send: host-serial:e986b63e:features → OKAY + features ✅

# Device-level after switch (WORKS - for reference):
Send: host:transport-id:270 → OKAY
Send: shell:echo hello → OKAY ✅
```

## Fix

Replace the two-step protocol with the one-shot `formatDeviceService()` format, which is the traditional ADB protocol format supported by all server versions.

## Why this only appears in multi-device environments

With a single connected device, `host:features` (without qualifier) automatically uses the only available device. The bug only manifests with 2+ devices connected.

## Testing

- Verified on Linux (Ubuntu 22.04) with 2 USB devices connected
- Both `host-serial:S:features` and `host-transport-id:N:features` formats work correctly
- The fix is backward-compatible as it uses the older, more widely supported command format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device feature retrieval with enhanced error handling for device selection scenarios.

* **Performance**
  * Optimized device feature requests to use a single connection instead of multiple steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->