### PR TITLE
feat(webcodecs): handle VideoDecoder reclaims

### DIFF
--- a/libraries/media-codec/src/h264.ts
+++ b/libraries/media-codec/src/h264.ts
@@ -217,6 +217,14 @@ export function searchConfiguration(buffer: Uint8Array) {
     throw new Error("Invalid data");
 }
 
+export function containsKeyFrame(buffer: Uint8Array) {
+    for (const nalu of annexBSplitNalu(buffer)) {
+        const naluType = nalu[0]! & 0x1f;
+        return naluType === 5; // Coded slice of an IDR picture
+    }
+    return false;
+}
+
 export interface Configuration {
     pictureParameterSet: Uint8Array;
     sequenceParameterSet: Uint8Array;

--- a/libraries/media-codec/src/h264.ts
+++ b/libraries/media-codec/src/h264.ts
@@ -220,7 +220,10 @@ export function searchConfiguration(buffer: Uint8Array) {
 export function containsKeyFrame(buffer: Uint8Array) {
     for (const nalu of annexBSplitNalu(buffer)) {
         const naluType = nalu[0]! & 0x1f;
-        return naluType === 5; // Coded slice of an IDR picture
+        if (naluType === 5) {
+            // Coded slice of an IDR picture
+            return true;
+        }
     }
     return false;
 }

--- a/libraries/scrcpy-decoder-webcodecs/src/video/codec/av1.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/codec/av1.ts
@@ -1,8 +1,6 @@
 import { Av1 } from "@yume-chan/media-codec";
 import { TransformStream } from "@yume-chan/stream-extra";
 
-import { convertFrameType } from "../utils/frame-type.js";
-
 import type { CodecTransformStream } from "./type.js";
 
 export class Av1TransformStream
@@ -35,7 +33,8 @@ export class Av1TransformStream
                 }
 
                 controller.enqueue({
-                    type: convertFrameType(packet.keyframe),
+                    // AV1 was added in Scrcpy 2.0 which must have `keyframe` property.
+                    type: packet.keyframe ? "key" : "delta",
                     timestamp: packet.timestamp,
                     data: packet.data,
                 });

--- a/libraries/scrcpy-decoder-webcodecs/src/video/codec/h264.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/codec/h264.ts
@@ -3,6 +3,15 @@ import { H264 } from "@yume-chan/media-codec";
 import { H26xTransformStream } from "./h26x.js";
 
 export class H264TransformStream extends H26xTransformStream {
+    override convertFrameType(
+        keyframe: boolean | undefined,
+        data: Uint8Array,
+    ): EncodedVideoChunkType {
+        // Older versions of Scrcpy doesn't have `keyframe` property,
+        // so detect it from the frame data.
+        return (keyframe ?? H264.containsKeyFrame(data)) ? "key" : "delta";
+    }
+
     override configure(data: Uint8Array): H26xTransformStream.Config {
         const configuration = H264.parseConfiguration(data);
 

--- a/libraries/scrcpy-decoder-webcodecs/src/video/codec/h265.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/codec/h265.ts
@@ -3,6 +3,13 @@ import { H265 } from "@yume-chan/media-codec";
 import { H26xTransformStream } from "./h26x.js";
 
 export class H265TransformStream extends H26xTransformStream {
+    override convertFrameType(
+        keyframe: boolean | undefined,
+    ): EncodedVideoChunkType {
+        // H.265 was added in Scrcpy 2.0 which must have `keyframe` property.
+        return keyframe ? "key" : "delta";
+    }
+
     override configure(data: Uint8Array): H26xTransformStream.Config {
         const configuration = H265.parseConfiguration(data);
 

--- a/libraries/scrcpy-decoder-webcodecs/src/video/codec/h26x.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/codec/h26x.ts
@@ -1,7 +1,5 @@
 import { TransformStream } from "@yume-chan/stream-extra";
 
-import { convertFrameType } from "../utils/frame-type.js";
-
 import type { CodecTransformStream } from "./type.js";
 
 export abstract class H26xTransformStream
@@ -20,13 +18,18 @@ export abstract class H26xTransformStream
                 }
 
                 controller.enqueue({
-                    type: convertFrameType(packet.keyframe),
+                    type: this.convertFrameType(packet.keyframe, packet.data),
                     timestamp: packet.timestamp,
                     data: packet.data,
                 });
             },
         });
     }
+
+    abstract convertFrameType(
+        keyframe: boolean | undefined,
+        data: Uint8Array,
+    ): EncodedVideoChunkType;
 
     abstract configure(data: Uint8Array): H26xTransformStream.Config;
 

--- a/libraries/scrcpy-decoder-webcodecs/src/video/codec/type.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/codec/type.ts
@@ -9,13 +9,6 @@ export type CodecTransformStream = TransformStream<
     CodecTransformStream.Output
 >;
 
-type PartialPlusUndefined<T> = {
-    [P in keyof T]?: T[P] | undefined;
-};
-
-type Optional<T extends object, Keys extends keyof T> = Omit<T, Keys> &
-    PartialPlusUndefined<Pick<T, Keys>>;
-
 export namespace CodecTransformStream {
     export type Input =
         | ScrcpyMediaStreamConfigurationPacket
@@ -34,7 +27,7 @@ export namespace CodecTransformStream {
         raw?: AllowSharedBufferSource;
     };
 
-    export type VideoChunk = Optional<EncodedVideoChunkInit, "type">;
+    export type VideoChunk = EncodedVideoChunkInit;
 
     export type Output = Config | VideoChunk;
 }

--- a/libraries/scrcpy-decoder-webcodecs/src/video/utils/frame-type.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/utils/frame-type.ts
@@ -1,7 +1,0 @@
-export function convertFrameType(
-    keyframe?: boolean,
-): EncodedVideoChunkType | undefined {
-    if (keyframe === true) return "key";
-    if (keyframe === false) return "delta";
-    return undefined;
-}

--- a/libraries/scrcpy-decoder-webcodecs/src/video/utils/index.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/utils/index.ts
@@ -1,4 +1,3 @@
-export * from "./frame-type.js";
 export * from "./snapshot.js";
 export * from "./timestamp.js";
 export * from "./video-decoder-stream.js";

--- a/libraries/scrcpy-decoder-webcodecs/src/video/utils/timestamp.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/utils/timestamp.ts
@@ -45,7 +45,7 @@ export class TimestampTransforms {
     /**
      * Timestamp of the last frame to be skipped by pause controller.
      */
-    #skipFramesUntil = 0;
+    #skipFramesUntil = -1;
 
     #addTimestamp = new TransformStream<
         ScrcpyVideoDecoderPauseController.Output,

--- a/libraries/scrcpy-decoder-webcodecs/src/video/utils/video-decoder-stream.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/utils/video-decoder-stream.ts
@@ -174,7 +174,7 @@ export class VideoDecoderStream
                     "decoder" in this.#state &&
                     this.#state.decoder.state === "configured"
                 ) {
-                    // This also delays closing `readable` and `writeable` streams
+                    // This also delays closing `readable` and `writable` streams
                     // (if they are not in error state) until all frames are decoded.
                     await this.#state.decoder.flush();
                 }

--- a/libraries/scrcpy-decoder-webcodecs/src/video/utils/video-decoder-stream.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/utils/video-decoder-stream.ts
@@ -5,6 +5,77 @@ import { concatBuffers, TransformStream } from "@yume-chan/stream-extra";
 
 import type { CodecTransformStream } from "../codec/type.js";
 
+type State =
+    | {
+          type: "unconfigured";
+      }
+    | {
+          type: "configured";
+          /**
+           * The native decoder.
+           *
+           * `transform`, `flush` and `cancel` callbacks don't need to
+           * check `#decoder.state` for "closed".
+           *
+           * Decoder can enter "closed" state by either:
+           *   - Encounter a decoding error: this triggers `controller.error`,
+           *     so no more transformer callbacks will be called.
+           *   - Calling `close` manually: this only happens in `flush` and `cancel`,
+           *     so no more transformer callbacks will be called.
+           */
+          decoder: VideoDecoder;
+          /** Saved configuration for use when resetting/re-creating the decoder. */
+          config: CodecTransformStream.Config;
+      }
+    | {
+          type: "decoding";
+          decoder: VideoDecoder;
+          /** Saved configuration for use when resetting/re-creating the decoder. */
+          config: CodecTransformStream.Config;
+          /** Saved frames since last keyframe for use when re-creating the decoder */
+          frames: CodecTransformStream.VideoChunk[];
+      }
+    | {
+          type: "reclaimed";
+          /** Saved configuration for use when re-creating the decoder. */
+          config: CodecTransformStream.Config;
+          /** Saved frames since last keyframe for use when re-creating the decoder */
+          frames: CodecTransformStream.VideoChunk[] | undefined;
+      };
+
+function decodeFirstKeyFrame(
+    decoder: VideoDecoder,
+    config: CodecTransformStream.Config,
+    chunk: CodecTransformStream.VideoChunk,
+) {
+    decoder.decode(
+        new EncodedVideoChunk({
+            type: "key",
+            timestamp: chunk.timestamp,
+            // `lib.dom.d.ts` doesn't allow `duration` to be undefined.
+            duration: chunk.duration!,
+            data: config.raw
+                ? concatBuffers([config.raw, chunk.data])
+                : chunk.data,
+        }),
+    );
+}
+
+function decodeFrame(
+    decoder: VideoDecoder,
+    chunk: CodecTransformStream.VideoChunk,
+) {
+    decoder.decode(
+        new EncodedVideoChunk({
+            type: chunk.type,
+            timestamp: chunk.timestamp,
+            // `lib.dom.d.ts` doesn't allow `duration` to be undefined.
+            duration: chunk.duration!,
+            data: chunk.data,
+        }),
+    );
+}
+
 export class VideoDecoderStream
     extends TransformStream<
         CodecTransformStream.Config | CodecTransformStream.VideoChunk,
@@ -14,25 +85,17 @@ export class VideoDecoderStream
 {
     #controller!: TransformStreamDefaultController<VideoFrame>;
 
-    /**
-     * The native decoder.
-     *
-     * `transform`, `flush` and `cancel` callbacks don't need to
-     * check `#decoder.state` for "closed".
-     *
-     * Decoder can enter "closed" state by either:
-     *   - Encounter a decoding error: this triggers `controller.error`,
-     *     so no more transformer callbacks will be called.
-     *   - Calling `close` manually: this only happens in `flush` and `cancel`,
-     *     so no more transformer callbacks will be called.
-     */
-    #decoder: VideoDecoder | undefined;
+    #state: State = { type: "unconfigured" };
 
     /**
      * Gets the number of frames waiting to be decoded.
      */
     get decodeQueueSize() {
-        return this.#decoder?.decodeQueueSize ?? 0;
+        if ("decoder" in this.#state) {
+            return this.#state.decoder.decodeQueueSize;
+        }
+
+        return 0;
     }
 
     #onDequeue = new EventEmitter<undefined>();
@@ -63,14 +126,8 @@ export class VideoDecoderStream
         return this.#counter.decoderResetCount;
     }
 
-    /**
-     * Saved decoder configuration for use when resetting the native decoder.
-     */
-    #config?: CodecTransformStream.Config;
-
-    #configured = false;
-
     #abortController = new AbortController();
+    #skipFramesBefore = -1;
 
     constructor() {
         let controller!: TransformStreamDefaultController<VideoFrame>;
@@ -80,10 +137,32 @@ export class VideoDecoderStream
                 // WARN: can't use `this` here
                 controller = controller_;
             },
-            transform: (chunk) => {
+            transform: async (chunk) => {
                 if ("codec" in chunk) {
-                    this.#config = chunk;
-                    this.#configured = false;
+                    // We want to validate the configuration right now
+                    switch (this.#state.type) {
+                        case "unconfigured":
+                        case "reclaimed":
+                            this.#state = {
+                                type: "configured",
+                                decoder: this.#createDecoder(chunk),
+                                config: chunk,
+                            };
+                            break;
+                        // @ts-expect-error: intentional case fallthrough
+                        case "decoding":
+                            await this.#state.decoder.flush();
+                        // fallthrough
+                        case "configured":
+                            // Reuse the existing decoder
+                            this.#state.decoder.configure(chunk);
+                            this.#state = {
+                                type: "configured",
+                                decoder: this.#state.decoder,
+                                config: chunk,
+                            };
+                            break;
+                    }
                     return;
                 }
 
@@ -91,11 +170,13 @@ export class VideoDecoderStream
             },
             flush: async () => {
                 // `flush` can only be called when `state` is "configured".
-                if (this.#decoder?.state === "configured") {
-                    // Wait for all queued frames to be decoded when
-                    // `writable` side ends without exception.
-                    // The `readable` side will wait for `flush` to complete before closing.
-                    await this.#decoder.flush();
+                if (
+                    "decoder" in this.#state &&
+                    this.#state.decoder.state === "configured"
+                ) {
+                    // This also delays closing `readable` and `writeable` streams
+                    // (if they are not in error state) until all frames are decoded.
+                    await this.#state.decoder.flush();
                 }
                 this.#dispose();
             },
@@ -106,12 +187,94 @@ export class VideoDecoderStream
         });
 
         this.#controller = controller;
-        this.#createVideoDecoder();
     }
 
-    #createVideoDecoder() {
+    #handleVideoChunk(chunk: CodecTransformStream.VideoChunk) {
+        switch (this.#state.type) {
+            case "unconfigured":
+                throw new Error("Decoder not configured");
+            case "configured": {
+                if (chunk.type === "delta") {
+                    throw new Error("Expect a keyframe but got a delta frame");
+                }
+
+                decodeFirstKeyFrame(
+                    this.#state.decoder,
+                    this.#state.config,
+                    chunk,
+                );
+
+                this.#state = {
+                    type: "decoding",
+                    decoder: this.#state.decoder,
+                    config: this.#state.config,
+                    frames: [chunk],
+                };
+                break;
+            }
+            case "decoding":
+                if (chunk.type === "key") {
+                    this.#state.frames.length = 0;
+                }
+                this.#state.frames.push(chunk);
+
+                decodeFrame(this.#state.decoder, chunk);
+                break;
+            case "reclaimed": {
+                const decoder = this.#createDecoder(this.#state.config);
+
+                if (chunk.type === "key") {
+                    decodeFirstKeyFrame(decoder, this.#state.config, chunk);
+
+                    this.#state = {
+                        type: "decoding",
+                        decoder: decoder,
+                        config: this.#state.config,
+                        frames: [chunk],
+                    };
+                    return;
+                }
+
+                if (!this.#state.frames) {
+                    // Reclaimed when configured but no frames have been decoded yet,
+                    // so a keyframe is required to start decoding.
+                    throw new Error("Expect a keyframe but got a delta frame");
+                }
+
+                decodeFirstKeyFrame(
+                    decoder,
+                    this.#state.config,
+                    this.#state.frames[0]!,
+                );
+
+                // `chunk`s must have monotonic timestamps, so we can skip all frames before `chunk`.
+                this.#skipFramesBefore = chunk.timestamp;
+                this.#state.frames.push(chunk);
+
+                for (const frame of this.#state.frames.slice(1)) {
+                    decodeFrame(decoder, frame);
+                }
+
+                this.#state = {
+                    type: "decoding",
+                    decoder: decoder,
+                    config: this.#state.config,
+                    frames: this.#state.frames,
+                };
+
+                break;
+            }
+        }
+    }
+
+    #createDecoder(config: CodecTransformStream.Config) {
         const decoder = new VideoDecoder({
             output: (frame) => {
+                if (frame.timestamp < this.#skipFramesBefore) {
+                    frame.close();
+                    return;
+                }
+
                 this.#counter.increaseFramesDecoded();
                 this.#controller.enqueue(frame);
             },
@@ -121,8 +284,32 @@ export class VideoDecoderStream
                     // (for example due to pausing decoding when the document is hidden).
                     // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/webcodecs/reclaimable_codec.cc;l=181;drc=aba14550ed0b4620deb59e7c5f551cbde8970fb3
                     // Reset states, it will be recreated in next `transform` call.
-                    this.#decoder = undefined;
-                    this.#configured = false;
+                    switch (this.#state.type) {
+                        case "unconfigured":
+                        case "reclaimed":
+                            throw new Error(
+                                "Unexpected state when reclaiming decoder",
+                            );
+                        case "configured":
+                            // Unlike `transform` callback,
+                            // this doesn't re-create the decoder immediately,
+                            // because the config has already been validated,
+                            // and since browser reclaims the decoder to save hardware resources,
+                            // we don't want to undo that by creating a new decoder immediately.
+                            this.#state = {
+                                type: "reclaimed",
+                                config: this.#state.config,
+                                frames: undefined,
+                            };
+                            break;
+                        case "decoding":
+                            this.#state = {
+                                type: "reclaimed",
+                                config: this.#state.config,
+                                frames: this.#state.frames,
+                            };
+                            break;
+                    }
                     return;
                 }
 
@@ -138,121 +325,21 @@ export class VideoDecoderStream
             { signal: this.#abortController.signal },
         );
 
-        this.#decoder = decoder;
+        decoder.configure(config);
+
         return decoder;
-    }
-
-    #handleVideoChunk(chunk: CodecTransformStream.VideoChunk) {
-        if (!this.#config) {
-            throw new Error("Decoder not configured");
-        }
-
-        if (chunk.type === "key") {
-            if (this.#decoder?.decodeQueueSize) {
-                // If the device is too slow to decode all frames,
-                // discard queued frames when next keyframe arrives.
-                // (decoding can only start from keyframes)
-                // This limits the maximum latency to 1 keyframe interval
-                // (60 frames by default).
-                this.#counter.addFramesSkippedDecoding(
-                    this.#decoder.decodeQueueSize,
-                );
-                this.#counter.increaseResetCount();
-                this.#decoder.reset();
-
-                // `reset` also resets the decoder configuration
-                // so we need to re-configure it again.
-                this.#configureAndDecodeFirstKeyFrame(chunk);
-                return;
-            }
-
-            if (!this.#configured) {
-                this.#configureAndDecodeFirstKeyFrame(chunk);
-                return;
-            }
-
-            this.#decoder!.decode(
-                // `type` has been checked to be "key"
-                new EncodedVideoChunk(chunk as EncodedVideoChunkInit),
-            );
-            return;
-        }
-
-        if (!this.#configured) {
-            if (chunk.type === undefined) {
-                // Older Scrcpy versions don't have frame type flag,
-                // but the first frame after configuration should be a keyframe
-                // (`VideoDecoder` will throw error if it's not)
-                this.#configureAndDecodeFirstKeyFrame(chunk);
-                return;
-            }
-
-            if (!this.#decoder) {
-                // When decoder is reclaimed, ignore delta frames until next keyframe arrives.
-                return;
-            }
-
-            throw new Error("Expect a keyframe but got a delta frame");
-        }
-
-        if (!this.#decoder) {
-            // When decoder is reclaimed, ignore delta frames until next keyframe arrives.
-            return;
-        }
-
-        this.#decoder?.decode(
-            new EncodedVideoChunk({
-                // Treat `undefined` as "key" otherwise it won't decode
-                type: chunk.type ?? "key",
-                timestamp: chunk.timestamp,
-                duration: chunk.duration!,
-                data: chunk.data,
-            }),
-        );
-    }
-
-    #configureAndDecodeFirstKeyFrame(chunk: CodecTransformStream.VideoChunk) {
-        // Lazily create the decoder
-        // Or re-create it if it has been closed due to `QuotaExceededError`
-        if (!this.#decoder) {
-            // Assigning the return value only for TypeScript to narrow
-            // `#decoder` type to non-nullable
-            this.#decoder = this.#createVideoDecoder();
-        }
-
-        const config = this.#config!;
-
-        this.#decoder.configure(config);
-        this.#configured = true;
-
-        if (config.raw) {
-            this.#decoder.decode(
-                new EncodedVideoChunk({
-                    type: "key",
-                    timestamp: chunk.timestamp,
-                    duration: chunk.duration!,
-                    data: concatBuffers([config.raw, chunk.data]),
-                }),
-            );
-            return;
-        }
-
-        this.#decoder.decode(
-            new EncodedVideoChunk({
-                type: "key",
-                timestamp: chunk.timestamp,
-                duration: chunk.duration!,
-                data: chunk.data,
-            }),
-        );
     }
 
     #dispose() {
         this.#abortController.abort();
         this.#onDequeue.dispose();
 
-        if (this.#decoder && this.#decoder.state !== "closed") {
-            this.#decoder.close();
+        if (
+            "decoder" in this.#state &&
+            this.#state.decoder.state !== "closed"
+        ) {
+            this.#state.decoder.close();
         }
+        this.#state = { type: "unconfigured" };
     }
 }

--- a/libraries/scrcpy-decoder-webcodecs/src/video/utils/video-decoder-stream.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/utils/video-decoder-stream.ts
@@ -12,6 +12,8 @@ export class VideoDecoderStream
     >
     implements ScrcpyVideoDecoderPerformanceCounterInterface
 {
+    #controller!: TransformStreamDefaultController<VideoFrame>;
+
     /**
      * The native decoder.
      *
@@ -24,13 +26,13 @@ export class VideoDecoderStream
      *   - Calling `close` manually: this only happens in `flush` and `cancel`,
      *     so no more transformer callbacks will be called.
      */
-    #decoder!: VideoDecoder;
+    #decoder: VideoDecoder | undefined;
 
     /**
      * Gets the number of frames waiting to be decoded.
      */
     get decodeQueueSize() {
-        return this.#decoder.decodeQueueSize;
+        return this.#decoder?.decodeQueueSize ?? 0;
     }
 
     #onDequeue = new EventEmitter<undefined>();
@@ -71,23 +73,12 @@ export class VideoDecoderStream
     #abortController = new AbortController();
 
     constructor() {
-        let decoder!: VideoDecoder;
+        let controller!: TransformStreamDefaultController<VideoFrame>;
 
         super({
-            start: (controller) => {
+            start: (controller_) => {
                 // WARN: can't use `this` here
-
-                decoder = new VideoDecoder({
-                    output: (frame) => {
-                        this.#counter.increaseFramesDecoded();
-                        controller.enqueue(frame);
-                    },
-                    error: (error) => {
-                        // Propagate decoder error to stream.
-                        controller.error(error);
-                        this.#dispose();
-                    },
-                });
+                controller = controller_;
             },
             transform: (chunk) => {
                 if ("codec" in chunk) {
@@ -100,7 +91,7 @@ export class VideoDecoderStream
             },
             flush: async () => {
                 // `flush` can only be called when `state` is "configured".
-                if (this.#decoder.state === "configured") {
+                if (this.#decoder?.state === "configured") {
                     // Wait for all queued frames to be decoded when
                     // `writable` side ends without exception.
                     // The `readable` side will wait for `flush` to complete before closing.
@@ -114,12 +105,41 @@ export class VideoDecoderStream
             },
         });
 
-        this.#decoder = decoder;
-        this.#decoder.addEventListener(
+        this.#controller = controller;
+        this.#createVideoDecoder();
+    }
+
+    #createVideoDecoder() {
+        const decoder = new VideoDecoder({
+            output: (frame) => {
+                this.#counter.increaseFramesDecoded();
+                this.#controller.enqueue(frame);
+            },
+            error: (error) => {
+                if (error.name === "QuotaExceededError") {
+                    // Chrome reclaims inactive `VideoDecoder`'s after 90 seconds
+                    // (for example due to pausing decoding when the document is hidden).
+                    // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/webcodecs/reclaimable_codec.cc;l=181;drc=aba14550ed0b4620deb59e7c5f551cbde8970fb3
+                    // Reset states, it will be recreated in next `transform` call.
+                    this.#decoder = undefined;
+                    this.#configured = false;
+                    return;
+                }
+
+                // Propagate other decoder errors to stream.
+                this.#controller.error(error);
+                this.#dispose();
+            },
+        });
+
+        decoder.addEventListener(
             "dequeue",
             () => this.#onDequeue.fire(undefined),
             { signal: this.#abortController.signal },
         );
+
+        this.#decoder = decoder;
+        return decoder;
     }
 
     #handleVideoChunk(chunk: CodecTransformStream.VideoChunk) {
@@ -128,7 +148,7 @@ export class VideoDecoderStream
         }
 
         if (chunk.type === "key") {
-            if (this.#decoder.decodeQueueSize) {
+            if (this.#decoder?.decodeQueueSize) {
                 // If the device is too slow to decode all frames,
                 // discard queued frames when next keyframe arrives.
                 // (decoding can only start from keyframes)
@@ -142,16 +162,16 @@ export class VideoDecoderStream
 
                 // `reset` also resets the decoder configuration
                 // so we need to re-configure it again.
-                this.#configureAndDecodeFirstKeyFrame(this.#config, chunk);
+                this.#configureAndDecodeFirstKeyFrame(chunk);
                 return;
             }
 
             if (!this.#configured) {
-                this.#configureAndDecodeFirstKeyFrame(this.#config, chunk);
+                this.#configureAndDecodeFirstKeyFrame(chunk);
                 return;
             }
 
-            this.#decoder.decode(
+            this.#decoder!.decode(
                 // `type` has been checked to be "key"
                 new EncodedVideoChunk(chunk as EncodedVideoChunkInit),
             );
@@ -162,14 +182,16 @@ export class VideoDecoderStream
             if (chunk.type === undefined) {
                 // Infer the first frame after configuration as keyframe
                 // (`VideoDecoder` will throw error if it's not)
-                this.#configureAndDecodeFirstKeyFrame(this.#config, chunk);
+                this.#configureAndDecodeFirstKeyFrame(chunk);
                 return;
             }
 
             throw new Error("Expect a keyframe but got a delta frame");
         }
 
-        this.#decoder.decode(
+        // Can't decode B-frames without a configured decoder
+        // Ignore them until next keyframe arrives
+        this.#decoder?.decode(
             new EncodedVideoChunk({
                 // Treat `undefined` as "key" otherwise it won't decode
                 type: chunk.type ?? "key",
@@ -180,10 +202,17 @@ export class VideoDecoderStream
         );
     }
 
-    #configureAndDecodeFirstKeyFrame(
-        config: CodecTransformStream.Config,
-        chunk: CodecTransformStream.VideoChunk,
-    ) {
+    #configureAndDecodeFirstKeyFrame(chunk: CodecTransformStream.VideoChunk) {
+        // Lazily create the decoder
+        // Or re-create it if it has been closed due to `QuotaExceededError`
+        if (!this.#decoder) {
+            // Assigning the return value only for TypeScript to narrow
+            // `#decoder` type to non-nullable
+            this.#decoder = this.#createVideoDecoder();
+        }
+
+        const config = this.#config!;
+
         this.#decoder.configure(config);
         this.#configured = true;
 
@@ -213,7 +242,7 @@ export class VideoDecoderStream
         this.#abortController.abort();
         this.#onDequeue.dispose();
 
-        if (this.#decoder.state !== "closed") {
+        if (this.#decoder && this.#decoder.state !== "closed") {
             this.#decoder.close();
         }
     }

--- a/libraries/scrcpy-decoder-webcodecs/src/video/utils/video-decoder-stream.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/utils/video-decoder-stream.ts
@@ -180,17 +180,26 @@ export class VideoDecoderStream
 
         if (!this.#configured) {
             if (chunk.type === undefined) {
-                // Infer the first frame after configuration as keyframe
+                // Older Scrcpy versions don't have frame type flag,
+                // but the first frame after configuration should be a keyframe
                 // (`VideoDecoder` will throw error if it's not)
                 this.#configureAndDecodeFirstKeyFrame(chunk);
+                return;
+            }
+
+            if (!this.#decoder) {
+                // When decoder is reclaimed, ignore delta frames until next keyframe arrives.
                 return;
             }
 
             throw new Error("Expect a keyframe but got a delta frame");
         }
 
-        // Can't decode B-frames without a configured decoder
-        // Ignore them until next keyframe arrives
+        if (!this.#decoder) {
+            // When decoder is reclaimed, ignore delta frames until next keyframe arrives.
+            return;
+        }
+
         this.#decoder?.decode(
             new EncodedVideoChunk({
                 // Treat `undefined` as "key" otherwise it won't decode

--- a/libraries/scrcpy-decoder-webcodecs/src/video/utils/video-decoder-stream.ts
+++ b/libraries/scrcpy-decoder-webcodecs/src/video/utils/video-decoder-stream.ts
@@ -287,9 +287,14 @@ export class VideoDecoderStream
                     switch (this.#state.type) {
                         case "unconfigured":
                         case "reclaimed":
-                            throw new Error(
-                                "Unexpected state when reclaiming decoder",
+                            // Don't throw, report errors to stream
+                            this.#controller.error(
+                                new Error(
+                                    "Unexpected state when reclaiming decoder",
+                                ),
                             );
+                            this.#dispose();
+                            return;
                         case "configured":
                             // Unlike `transform` callback,
                             // this doesn't re-create the decoder immediately,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video stream decoding stability with an explicit decoder lifecycle state machine, safer reconfiguration/flush behavior, and more reliable recovery after decoder reclaim.
  * Corrected frame classification for H.264/H.265/AV1 by using keyframe hints when available, with H.264 auto-detecting keyframes from data when hints are missing.
  * Fixed timestamp skipping so very early timestamps are no longer prematurely closed/dropped.
* **New Features**
  * Added an exported `containsKeyFrame` helper for H.264 Annex B buffers.
* **Compatibility**
  * Updated exported codec `VideoChunk` typing to require the `type` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->