### PR TITLE
fix(adb/server): forward options when creating device connections

### DIFF
--- a/libraries/adb/src/server/client.spec.ts
+++ b/libraries/adb/src/server/client.spec.ts
@@ -86,4 +86,82 @@ describe("AdbServerClient", () => {
         ]);
         await socket.close();
     });
+
+    it("forwards connection options through waitFor version preflight", async () => {
+        const abortController = new AbortController();
+        const options: AdbServerClient.ServerConnectionOptions = {
+            signal: abortController.signal,
+            unref: true,
+        };
+        const receivedOptions: (
+            AdbServerClient.ServerConnectionOptions | undefined
+        )[] = [];
+        const responses = [encodeUtf8("OKAY00040029"), encodeUtf8("OKAYOKAY")];
+        let connectionIndex = 0;
+        const connector: AdbServerClient.ServerConnector = {
+            connect(received) {
+                receivedOptions.push(received);
+                const response = responses[connectionIndex]!;
+                connectionIndex += 1;
+                return createConnection(response, []);
+            },
+            addReverseTunnel() {
+                throw new Error("Not implemented");
+            },
+            removeReverseTunnel() {
+                throw new Error("Not implemented");
+            },
+            clearReverseTunnels() {
+                throw new Error("Not implemented");
+            },
+        };
+        const client = new AdbServerClient(connector);
+
+        await client.waitFor({ serial: "serial" }, "disconnect", options);
+
+        assert.strictEqual(receivedOptions.length, 2);
+        for (const received of receivedOptions) {
+            assert.strictEqual(received?.signal, abortController.signal);
+            assert.strictEqual(received?.unref, true);
+        }
+    });
+
+    it("forwards connection options through waitForDisconnect version preflight", async () => {
+        const abortController = new AbortController();
+        const options: AdbServerClient.ServerConnectionOptions = {
+            signal: abortController.signal,
+            unref: true,
+        };
+        const receivedOptions: (
+            AdbServerClient.ServerConnectionOptions | undefined
+        )[] = [];
+        const responses = [encodeUtf8("OKAY00040029"), encodeUtf8("OKAYOKAY")];
+        let connectionIndex = 0;
+        const connector: AdbServerClient.ServerConnector = {
+            connect(received) {
+                receivedOptions.push(received);
+                const response = responses[connectionIndex]!;
+                connectionIndex += 1;
+                return createConnection(response, []);
+            },
+            addReverseTunnel() {
+                throw new Error("Not implemented");
+            },
+            removeReverseTunnel() {
+                throw new Error("Not implemented");
+            },
+            clearReverseTunnels() {
+                throw new Error("Not implemented");
+            },
+        };
+        const client = new AdbServerClient(connector);
+
+        await client.waitForDisconnect(42n, options);
+
+        assert.strictEqual(receivedOptions.length, 2);
+        for (const received of receivedOptions) {
+            assert.strictEqual(received?.signal, abortController.signal);
+            assert.strictEqual(received?.unref, true);
+        }
+    });
 });

--- a/libraries/adb/src/server/client.spec.ts
+++ b/libraries/adb/src/server/client.spec.ts
@@ -1,0 +1,89 @@
+import * as assert from "node:assert";
+import { describe, it } from "node:test";
+
+import {
+    AbortController,
+    MaybeConsumable,
+    ReadableStream,
+} from "@yume-chan/stream-extra";
+import { decodeUtf8, encodeUtf8 } from "@yume-chan/struct";
+
+import { AdbServerClient } from "./client.js";
+
+function createConnection(
+    response: Uint8Array,
+    requests: string[],
+): AdbServerClient.ServerConnection {
+    return {
+        readable: new ReadableStream({
+            start(controller) {
+                controller.enqueue(response);
+                controller.close();
+            },
+        }),
+        writable: new MaybeConsumable.WritableStream({
+            write(chunk) {
+                requests.push(decodeUtf8(chunk));
+            },
+        }),
+        closed: Promise.resolve(undefined),
+        async close() {},
+    };
+}
+
+describe("AdbServerClient", () => {
+    it("forwards connection options through serial device selection", async () => {
+        const abortController = new AbortController();
+        const options: AdbServerClient.ServerConnectionOptions = {
+            signal: abortController.signal,
+            unref: true,
+        };
+        const receivedOptions: (
+            AdbServerClient.ServerConnectionOptions | undefined
+        )[] = [];
+        const requests: string[][] = [[], []];
+        const serviceResponse = new Uint8Array(16);
+        serviceResponse.set(encodeUtf8("OKAY"));
+        serviceResponse[4] = 42;
+        serviceResponse.set(encodeUtf8("OKAY"), 12);
+        const responses = [encodeUtf8("OKAY00040029"), serviceResponse];
+        let connectionIndex = 0;
+        const connector: AdbServerClient.ServerConnector = {
+            connect(received) {
+                receivedOptions.push(received);
+                const response = responses[connectionIndex]!;
+                const connectionRequests = requests[connectionIndex]!;
+                connectionIndex += 1;
+                return createConnection(response, connectionRequests);
+            },
+            addReverseTunnel() {
+                throw new Error("Not implemented");
+            },
+            removeReverseTunnel() {
+                throw new Error("Not implemented");
+            },
+            clearReverseTunnels() {
+                throw new Error("Not implemented");
+            },
+        };
+        const client = new AdbServerClient(connector);
+
+        const socket = await client.createDeviceConnection(
+            { serial: "serial" },
+            "localabstract:service",
+            options,
+        );
+
+        assert.strictEqual(socket.transportId, 42n);
+        assert.strictEqual(receivedOptions.length, 2);
+        for (const received of receivedOptions) {
+            assert.strictEqual(received?.signal, abortController.signal);
+            assert.strictEqual(received?.unref, true);
+        }
+        assert.deepStrictEqual(requests, [
+            ["000chost:version"],
+            ["0018host:tport:serial:serial", "0015localabstract:service"],
+        ]);
+        await socket.close();
+    });
+});

--- a/libraries/adb/src/server/client.ts
+++ b/libraries/adb/src/server/client.ts
@@ -437,7 +437,7 @@ export class AdbServerClient {
         options?: AdbServerClient.ServerConnectionOptions,
     ): Promise<void> {
         if (state === "disconnect") {
-            await this.validateVersion(41);
+            await this.validateVersion(41, options);
         }
 
         return this.#waitForUnchecked(device, state, options);
@@ -447,7 +447,7 @@ export class AdbServerClient {
         transportId: bigint,
         options?: AdbServerClient.ServerConnectionOptions,
     ): Promise<void> {
-        const serverVersion = await this.getVersion();
+        const serverVersion = await this.getVersion(options);
         if (serverVersion >= 41) {
             return this.#waitForUnchecked(
                 { transportId },

--- a/libraries/adb/src/server/client.ts
+++ b/libraries/adb/src/server/client.ts
@@ -193,8 +193,10 @@ export class AdbServerClient {
     /**
      * `adb version`
      */
-    async getVersion(): Promise<number> {
-        const connection = await this.createConnection("host:version");
+    async getVersion(
+        options?: AdbServerClient.ServerConnectionOptions,
+    ): Promise<number> {
+        const connection = await this.createConnection("host:version", options);
         try {
             const length = hexToNumber(await connection.readExactly(4));
             const version = hexToNumber(await connection.readExactly(length));
@@ -204,8 +206,11 @@ export class AdbServerClient {
         }
     }
 
-    async validateVersion(minimalVersion: number) {
-        const version = await this.getVersion();
+    async validateVersion(
+        minimalVersion: number,
+        options?: AdbServerClient.ServerConnectionOptions,
+    ) {
+        const version = await this.getVersion(options);
         if (version < minimalVersion) {
             throw new Error(
                 `adb server version (${version}) doesn't match this client (${minimalVersion})`,
@@ -324,34 +329,36 @@ export class AdbServerClient {
      * Creates a connection that will forward the service to device.
      * @param device The device selector
      * @param service The service to forward
+     * @param options The server connection options
      * @returns An `AdbServerClient.Socket` that can be used to communicate with the service
      */
     async createDeviceConnection(
         device: AdbServerClient.DeviceSelector,
         service: string,
+        options?: AdbServerClient.ServerConnectionOptions,
     ): Promise<AdbServerClient.Socket> {
         let switchService: string;
         let transportId: bigint | undefined;
         if (!device) {
-            await this.validateVersion(41);
+            await this.validateVersion(41, options);
             switchService = `host:tport:any`;
         } else if ("transportId" in device) {
             switchService = `host:transport-id:${device.transportId}`;
             transportId = device.transportId;
         } else if ("serial" in device) {
-            await this.validateVersion(41);
+            await this.validateVersion(41, options);
             switchService = `host:tport:serial:${device.serial}`;
         } else if ("usb" in device) {
-            await this.validateVersion(41);
+            await this.validateVersion(41, options);
             switchService = `host:tport:usb`;
         } else if ("tcp" in device) {
-            await this.validateVersion(41);
+            await this.validateVersion(41, options);
             switchService = `host:tport:local`;
         } else {
             throw new TypeError("Invalid device selector");
         }
 
-        const connection = await this.createConnection(switchService);
+        const connection = await this.createConnection(switchService, options);
 
         try {
             await connection.writeString(service);


### PR DESCRIPTION
## Summary

- Accept optional server connection options in `getVersion`, `validateVersion`, and `createDeviceConnection`.
- Forward the same options to both the version preflight and the device service connection.
- Add a deterministic serial-selector protocol test covering `signal` and `unref`.

This is additive and keeps existing callers unchanged. It does not change connector implementations, retries, timeouts, reconnection, or selector identity.

## Verification

- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `git diff --check`

Fixes #856.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional connection settings when fetching server versions and validating minimum versions, and when creating device/service connections.
* **Bug Fixes**
  * Connection options (including cancellation signals and connection lifecycle behavior) are now consistently preserved across version checks and device connection setup flows.
* **Tests**
  * Added coverage ensuring connection options are forwarded correctly and that the expected protocol request sequence is written during device connection creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->