### PR TITLE
fix(adb): close subprocesses after waiting

### DIFF
--- a/libraries/adb/src/service/subprocess/none/spawner.spec.ts
+++ b/libraries/adb/src/service/subprocess/none/spawner.spec.ts
@@ -1,0 +1,84 @@
+import * as assert from "node:assert";
+import { describe, it, mock } from "node:test";
+
+import { PromiseResolver } from "@yume-chan/async";
+import type { ReadableStreamDefaultController } from "@yume-chan/stream-extra";
+import { ReadableStream, WritableStream } from "@yume-chan/stream-extra";
+
+import type { AdbNoneProtocolProcess } from "./spawner.js";
+import { adbNoneProtocolSpawner } from "./spawner.js";
+
+describe("adbNoneProtocolSpawner", () => {
+    it("`wait` should await killing the process", async () => {
+        const killStarted = new PromiseResolver<void>();
+        const killFinished = new PromiseResolver<void>();
+        const kill = mock.fn(async () => {
+            killStarted.resolve();
+            await killFinished.promise;
+        });
+        const process = {
+            stdin: new WritableStream(),
+            output: new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array([1, 2, 3]));
+                    controller.close();
+                },
+            }),
+            exited: Promise.resolve(),
+            kill,
+        } satisfies AdbNoneProtocolProcess;
+        const spawn = adbNoneProtocolSpawner(() => Promise.resolve(process));
+
+        const waitPromise = (async () => await spawn(["echo"]).wait())();
+        let waitSettled = false;
+        void waitPromise.then(
+            () => {
+                waitSettled = true;
+            },
+            () => {
+                waitSettled = true;
+            },
+        );
+
+        await killStarted.promise;
+        assert.strictEqual(waitSettled, false);
+
+        killFinished.resolve();
+        assert.deepStrictEqual(
+            await waitPromise,
+            new Uint8Array([1, 2, 3]),
+        );
+        assert.strictEqual(kill.mock.callCount(), 1);
+    });
+
+    it("`wait` should kill the process when piping stdin fails", async () => {
+        const error = new Error("stdin failed");
+        let outputController!: ReadableStreamDefaultController<Uint8Array>;
+        const kill = mock.fn(() => {
+            outputController.close();
+        });
+        const process = {
+            stdin: new WritableStream(),
+            output: new ReadableStream({
+                start(controller) {
+                    outputController = controller;
+                },
+            }),
+            exited: new Promise<void>(() => {}),
+            kill,
+        } satisfies AdbNoneProtocolProcess;
+        const spawn = adbNoneProtocolSpawner(() => Promise.resolve(process));
+        const stdin = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.error(error);
+            },
+        });
+
+        await assert.rejects(
+            async () => await spawn(["cat"]).wait({ stdin }),
+            error,
+        );
+
+        assert.strictEqual(kill.mock.callCount(), 1);
+    });
+});

--- a/libraries/adb/src/service/subprocess/none/spawner.ts
+++ b/libraries/adb/src/service/subprocess/none/spawner.ts
@@ -55,11 +55,15 @@ export function adbNoneProtocolSpawner(
 
         processPromise.wait = (options) => {
             const waitPromise = processPromise.then(async (process) => {
-                const [, output] = await Promise.all([
-                    options?.stdin?.pipeTo(process.stdin),
-                    process.output.pipeThrough(new ToArrayStream()),
-                ]);
-                return output;
+                try {
+                    const [, output] = await Promise.all([
+                        options?.stdin?.pipeTo(process.stdin),
+                        process.output.pipeThrough(new ToArrayStream()),
+                    ]);
+                    return output;
+                } finally {
+                    await process.kill();
+                }
             });
 
             return createLazyPromise(

--- a/libraries/adb/src/service/subprocess/shell/spawner.spec.ts
+++ b/libraries/adb/src/service/subprocess/shell/spawner.spec.ts
@@ -1,0 +1,98 @@
+import * as assert from "node:assert";
+import { describe, it, mock } from "node:test";
+
+import { PromiseResolver } from "@yume-chan/async";
+import type { ReadableStreamDefaultController } from "@yume-chan/stream-extra";
+import { ReadableStream, WritableStream } from "@yume-chan/stream-extra";
+
+import type { AdbShellProtocolProcess } from "./spawner.js";
+import { adbShellProtocolSpawner } from "./spawner.js";
+
+describe("adbShellProtocolSpawner", () => {
+    it("`wait` should await killing the process", async () => {
+        const killStarted = new PromiseResolver<void>();
+        const killFinished = new PromiseResolver<void>();
+        const kill = mock.fn(async () => {
+            killStarted.resolve();
+            await killFinished.promise;
+        });
+        const process = {
+            stdin: new WritableStream(),
+            stdout: new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array([1, 2, 3]));
+                    controller.close();
+                },
+            }),
+            stderr: new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array([4, 5, 6]));
+                    controller.close();
+                },
+            }),
+            exited: Promise.resolve(42),
+            kill,
+        } satisfies AdbShellProtocolProcess;
+        const spawn = adbShellProtocolSpawner(() => Promise.resolve(process));
+
+        const waitPromise = (async () => await spawn(["echo"]).wait())();
+        let waitSettled = false;
+        void waitPromise.then(
+            () => {
+                waitSettled = true;
+            },
+            () => {
+                waitSettled = true;
+            },
+        );
+
+        await killStarted.promise;
+        assert.strictEqual(waitSettled, false);
+
+        killFinished.resolve();
+        assert.deepStrictEqual(await waitPromise, {
+            stdout: new Uint8Array([1, 2, 3]),
+            stderr: new Uint8Array([4, 5, 6]),
+            exitCode: 42,
+        });
+        assert.strictEqual(kill.mock.callCount(), 1);
+    });
+
+    it("`wait` should kill the process when piping stdin fails", async () => {
+        const error = new Error("stdin failed");
+        let stdoutController!: ReadableStreamDefaultController<Uint8Array>;
+        let stderrController!: ReadableStreamDefaultController<Uint8Array>;
+        const kill = mock.fn(() => {
+            stdoutController.close();
+            stderrController.close();
+        });
+        const process = {
+            stdin: new WritableStream(),
+            stdout: new ReadableStream({
+                start(controller) {
+                    stdoutController = controller;
+                },
+            }),
+            stderr: new ReadableStream({
+                start(controller) {
+                    stderrController = controller;
+                },
+            }),
+            exited: new Promise<number>(() => {}),
+            kill,
+        } satisfies AdbShellProtocolProcess;
+        const spawn = adbShellProtocolSpawner(() => Promise.resolve(process));
+        const stdin = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.error(error);
+            },
+        });
+
+        await assert.rejects(
+            async () => await spawn(["cat"]).wait({ stdin }),
+            error,
+        );
+
+        assert.strictEqual(kill.mock.callCount(), 1);
+    });
+});

--- a/libraries/adb/src/service/subprocess/shell/spawner.ts
+++ b/libraries/adb/src/service/subprocess/shell/spawner.ts
@@ -67,17 +67,21 @@ export function adbShellProtocolSpawner(
 
         processPromise.wait = (options) => {
             const waitPromise = processPromise.then(async (process) => {
-                const [, stdout, stderr, exitCode] = await Promise.all([
-                    options?.stdin?.pipeTo(process.stdin),
-                    process.stdout.pipeThrough(new ToArrayStream()),
-                    process.stderr.pipeThrough(new ToArrayStream()),
-                    process.exited,
-                ]);
-                return {
-                    stdout,
-                    stderr,
-                    exitCode,
-                } satisfies AdbShellProtocolSpawner.WaitResult<Uint8Array[]>;
+                try {
+                    const [, stdout, stderr, exitCode] = await Promise.all([
+                        options?.stdin?.pipeTo(process.stdin),
+                        process.stdout.pipeThrough(new ToArrayStream()),
+                        process.stderr.pipeThrough(new ToArrayStream()),
+                        process.exited,
+                    ]);
+                    return {
+                        stdout,
+                        stderr,
+                        exitCode,
+                    } satisfies AdbShellProtocolSpawner.WaitResult<Uint8Array[]>;
+                } finally {
+                    await process.kill();
+                }
             });
 
             return createLazyPromise(


### PR DESCRIPTION
## Summary

- close none- and shell-protocol subprocesses whenever `wait()` settles
- await asynchronous `kill()` implementations before resolving or rejecting `wait()`
- add regression coverage for successful waits and failed stdin pipelines in both protocols

Without this cleanup, an error from a caller-provided stdin stream can reject `wait()` while the command and its ADB socket remain open.

Fixes #859.

## Testing

- `pnpm --filter @yume-chan/adb lint`
- `pnpm --filter @yume-chan/adb build`
- `pnpm --filter @yume-chan/adb test`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess waiting to ensure processes are terminated after output collection completes.
  * Ensured processes are cleaned up when input piping fails.
  * Preserved command output and errors while reliably completing process termination.

* **Tests**
  * Added coverage for delayed process termination, output collection, exit codes, and input-stream failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->