### PR TITLE
fix(adb): prevent unhandled disconnect rejection

### DIFF
--- a/.changeset/quiet-pandas-disconnect.md
+++ b/.changeset/quiet-pandas-disconnect.md
@@ -1,0 +1,5 @@
+---
+"@yume-chan/adb": patch
+---
+
+Prevent disconnect monitor failures from leaking an unhandled promise rejection.

--- a/libraries/adb/src/server/client.spec.ts
+++ b/libraries/adb/src/server/client.spec.ts
@@ -1,0 +1,63 @@
+import * as assert from "node:assert";
+import { describe, it } from "node:test";
+import { setImmediate } from "node:timers/promises";
+
+import type { AbortSignal } from "@yume-chan/stream-extra";
+
+import { AdbServerClient } from "./client.js";
+
+describe("AdbServerClient", () => {
+    it("does not leak a rejected disconnect monitor promise", async () => {
+        const connector: AdbServerClient.ServerConnector = {
+            connect() {
+                throw new Error("Not implemented");
+            },
+            addReverseTunnel() {
+                throw new Error("Not implemented");
+            },
+            removeReverseTunnel() {
+                throw new Error("Not implemented");
+            },
+            clearReverseTunnels() {
+                throw new Error("Not implemented");
+            },
+        };
+        const client = new AdbServerClient(connector);
+        client.getDeviceFeatures = () =>
+            Promise.resolve({
+                transportId: 1n,
+                features: [],
+            });
+        client.getDevices = () =>
+            Promise.resolve([
+                {
+                    serial: "device",
+                    state: "device",
+                    authenticating: false,
+                    transportId: 1n,
+                },
+            ]);
+
+        let rejectDisconnect: ((reason: Error) => void) | undefined;
+        let disconnectSignal: AbortSignal | undefined;
+        client.waitForDisconnect = (_transportId, options) =>
+            new Promise((_, reject) => {
+                disconnectSignal = options?.signal;
+                rejectDisconnect = reject;
+            });
+
+        const transport = await client.createTransport({ serial: "device" });
+        assert.ok(rejectDisconnect);
+        const handledDisconnect = assert.rejects(
+            transport.disconnected,
+            /disconnect failed/,
+        );
+
+        rejectDisconnect(new Error("disconnect failed"));
+        await handledDisconnect;
+        // Give Node.js a turn to report any cleanup-derived rejection.
+        await setImmediate();
+
+        assert.strictEqual(disconnectSignal?.aborted, true);
+    });
+});

--- a/libraries/adb/src/server/client.ts
+++ b/libraries/adb/src/server/client.ts
@@ -472,7 +472,11 @@ export class AdbServerClient {
             disconnected,
         );
 
-        void transport.disconnected.finally(() => waitAbortController.abort());
+        const abortDisconnectWait = () => waitAbortController.abort();
+        void transport.disconnected.then(
+            abortDisconnectWait,
+            abortDisconnectWait,
+        );
 
         return transport;
     }


### PR DESCRIPTION
## What

- Replace the ignored `.finally()` cleanup chain with explicit fulfillment and rejection handlers.
- Preserve the original disconnect-monitor rejection while still aborting the redundant wait.
- Add a regression test that exercises a rejected disconnect monitor under Node.js.
- Add a patch changeset for `@yume-chan/adb`.

## Why

`Promise.prototype.finally()` creates a new promise that rejects with the original reason. The previous implementation discarded that derived promise, so a disconnect-monitor failure could surface as an unhandled rejection even when the consumer handled `transport.disconnected`.

In Node.js configurations where unhandled rejections are fatal, this can terminate the consuming process during device disconnect or ADB server failures.

## Root cause

The cleanup callback was attached with:

```ts
void transport.disconnected.finally(() => waitAbortController.abort());
```

Handling the original promise does not handle the rejected promise returned by `.finally()`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm lint`
- `pnpm test`
- `pnpm --filter @yume-chan/adb test` (93 tests passed)

Closes #862.

Related downstream report: https://github.com/web-infra-dev/midscene/issues/2836


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause unhandled promise rejection errors when a connection disconnects unexpectedly.
  * Ensured disconnect monitoring is properly cleaned up whether the connection closes successfully or with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->